### PR TITLE
Allow the use of custom key.

### DIFF
--- a/lib/src/model/pluto_row.dart
+++ b/lib/src/model/pluto_row.dart
@@ -13,9 +13,10 @@ class PlutoRow {
     @required this.cells,
     this.sortIdx,
     bool checked = false,
+    Key key = null,
   })  : _checked = checked,
         _state = PlutoRowState.none,
-        _key = UniqueKey();
+        _key = key??UniqueKey();
 
   /// The state value that the checkbox is checked.
   /// If the enableRowChecked value of the [PlutoColumn] property is set to true,


### PR DESCRIPTION
In PlutoGridOnSelectedEvent, you can associate custom data through `event.row.key`.