### PR TITLE
Feat 229 secondary tap

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -28,8 +28,12 @@ import 'screen/feature/text_type_column_screen.dart';
 import 'screen/feature/time_type_column_screen.dart';
 import 'screen/feature/value_formatter_screen.dart';
 import 'screen/home_screen.dart';
+import 'dart:html';
 
 void main() {
+  // required to access right click in a browser.
+  // needs removing for desktop etc.
+  document.onContextMenu.listen((event) => event.preventDefault());
   runApp(MyApp());
 }
 

--- a/example/lib/screen/development_screen.dart
+++ b/example/lib/screen/development_screen.dart
@@ -191,6 +191,10 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
             print('Double click A Row.');
             print(e.row?.cells['column1']?.value);
           },
+          onRowSecondaryTap: (e) {
+            print('Secondary click A Row.(${e.offset})');
+            print(e.row?.cells['column1']?.value);
+          },
           createHeader: (PlutoGridStateManager stateManager) {
             return SingleChildScrollView(
               scrollDirection: Axis.horizontal,

--- a/example/lib/screen/development_screen.dart
+++ b/example/lib/screen/development_screen.dart
@@ -187,6 +187,10 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
             stateManager!.setShowColumnFilter(true);
           },
           onRowChecked: handleOnRowChecked,
+          onRowDoubleTap: (e) {
+            print('Double click A Row.');
+            print(e.row?.cells['column1']?.value);
+          },
           createHeader: (PlutoGridStateManager stateManager) {
             return SingleChildScrollView(
               scrollDirection: Axis.horizontal,

--- a/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
+++ b/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
@@ -42,6 +42,9 @@ class PlutoGridCellGestureEvent extends PlutoGridEvent {
       case PlutoGridGestureType.onDoubleTap:
         _onDoubleTap(stateManager!);
         break;
+      case PlutoGridGestureType.onSecondaryTap:
+        _onSecondaryTap(stateManager!);
+        break;
       default:
     }
   }
@@ -95,6 +98,11 @@ class PlutoGridCellGestureEvent extends PlutoGridEvent {
         row: stateManager.getRowByIdx(rowIdx), cell: cell));
   }
 
+  void _onSecondaryTap(PlutoGridStateManager stateManager) {
+    stateManager.onRowSecondaryTap!(PlutoGridOnRowSecondaryTapEvent(
+        row: stateManager.getRowByIdx(rowIdx), cell: cell, offset: offset));
+  }
+
   bool _setKeepFocusAndCurrentCell(PlutoGridStateManager stateManager) {
     if (stateManager.hasFocus) {
       return false;
@@ -145,4 +153,5 @@ enum PlutoGridGestureType {
   onLongPressMoveUpdate,
   onLongPressEnd,
   onDoubleTap,
+  onSecondaryTap,
 }

--- a/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
+++ b/lib/src/manager/event/pluto_grid_cell_gesture_event.dart
@@ -26,14 +26,23 @@ class PlutoGridCellGestureEvent extends PlutoGridEvent {
       return;
     }
 
-    if (gestureType.isOnTapUp) {
-      _onTapUp(stateManager!);
-    } else if (gestureType.isOnLongPressStart) {
-      _onLongPressStart(stateManager!);
-    } else if (gestureType.isOnLongPressMoveUpdate) {
-      _onLongPressMoveUpdate(stateManager!);
-    } else if (gestureType.isOnLongPressEnd) {
-      _onLongPressEnd(stateManager!);
+    switch (gestureType) {
+      case PlutoGridGestureType.onTapUp:
+        _onTapUp(stateManager!);
+        break;
+      case PlutoGridGestureType.onLongPressStart:
+        _onLongPressStart(stateManager!);
+        break;
+      case PlutoGridGestureType.onLongPressMoveUpdate:
+        _onLongPressMoveUpdate(stateManager!);
+        break;
+      case PlutoGridGestureType.onLongPressEnd:
+        _onLongPressEnd(stateManager!);
+        break;
+      case PlutoGridGestureType.onDoubleTap:
+        _onDoubleTap(stateManager!);
+        break;
+      default:
     }
   }
 
@@ -79,6 +88,11 @@ class PlutoGridCellGestureEvent extends PlutoGridEvent {
     _setCurrentCell(stateManager, cell, rowIdx);
 
     stateManager.setSelecting(false);
+  }
+
+  void _onDoubleTap(PlutoGridStateManager stateManager) {
+    stateManager.onRowDoubleTap!(PlutoGridOnRowDoubleTapEvent(
+        row: stateManager.getRowByIdx(rowIdx), cell: cell));
   }
 
   bool _setKeepFocusAndCurrentCell(PlutoGridStateManager stateManager) {
@@ -130,15 +144,5 @@ enum PlutoGridGestureType {
   onLongPressStart,
   onLongPressMoveUpdate,
   onLongPressEnd,
-}
-
-extension PlutoGridGestureTypeExtension on PlutoGridGestureType? {
-  bool get isOnTapUp => this == PlutoGridGestureType.onTapUp;
-
-  bool get isOnLongPressStart => this == PlutoGridGestureType.onLongPressStart;
-
-  bool get isOnLongPressMoveUpdate =>
-      this == PlutoGridGestureType.onLongPressMoveUpdate;
-
-  bool get isOnLongPressEnd => this == PlutoGridGestureType.onLongPressEnd;
+  onDoubleTap,
 }

--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -56,6 +56,7 @@ class PlutoGridStateManager extends PlutoGridState {
     PlutoOnChangedEventCallback? onChangedEventCallback,
     PlutoOnSelectedEventCallback? onSelectedEventCallback,
     PlutoOnRowCheckedEventCallback? onRowCheckedEventCallback,
+    PlutoOnRowDoubleTapEventCallback? onRowDoubleTapEventCallback,
     CreateHeaderCallBack? createHeader,
     CreateFooterCallBack? createFooter,
     PlutoGridConfiguration? configuration,
@@ -68,6 +69,7 @@ class PlutoGridStateManager extends PlutoGridState {
     setOnChanged(onChangedEventCallback);
     setOnSelected(onSelectedEventCallback);
     setOnRowChecked(onRowCheckedEventCallback);
+    setOnRowDoubleTap(onRowDoubleTapEventCallback);
     setCreateHeader(createHeader);
     setCreateFooter(createFooter);
     setConfiguration(configuration);

--- a/lib/src/manager/pluto_grid_state_manager.dart
+++ b/lib/src/manager/pluto_grid_state_manager.dart
@@ -57,6 +57,7 @@ class PlutoGridStateManager extends PlutoGridState {
     PlutoOnSelectedEventCallback? onSelectedEventCallback,
     PlutoOnRowCheckedEventCallback? onRowCheckedEventCallback,
     PlutoOnRowDoubleTapEventCallback? onRowDoubleTapEventCallback,
+    PlutoOnRowSecondaryTapEventCallback? onRowSecondaryTapEventCallback,
     CreateHeaderCallBack? createHeader,
     CreateFooterCallBack? createFooter,
     PlutoGridConfiguration? configuration,
@@ -70,6 +71,7 @@ class PlutoGridStateManager extends PlutoGridState {
     setOnSelected(onSelectedEventCallback);
     setOnRowChecked(onRowCheckedEventCallback);
     setOnRowDoubleTap(onRowDoubleTapEventCallback);
+    setOnRowSecondaryTap(onRowSecondaryTapEventCallback);
     setCreateHeader(createHeader);
     setCreateFooter(createFooter);
     setConfiguration(configuration);

--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -47,6 +47,8 @@ abstract class IGridState {
 
   void setOnRowDoubleTap(PlutoOnRowDoubleTapEventCallback? onDoubleTap);
 
+  void setOnRowSecondaryTap(PlutoOnRowSecondaryTapEventCallback? onSecondaryTap);
+
   void setConfiguration(PlutoGridConfiguration configuration);
 
   void resetCurrentState({bool notify = true});
@@ -92,6 +94,10 @@ mixin GridState implements IPlutoGridState {
 
   PlutoOnRowDoubleTapEventCallback? _onRowDoubleTap;
 
+  PlutoOnRowSecondaryTapEventCallback? get onRowSecondaryTap => _onRowSecondaryTap;
+
+  PlutoOnRowSecondaryTapEventCallback? _onRowSecondaryTap;
+
   CreateHeaderCallBack? get createHeader => _createHeader;
 
   CreateHeaderCallBack? _createHeader;
@@ -128,6 +134,10 @@ mixin GridState implements IPlutoGridState {
 
   void setOnRowDoubleTap(PlutoOnRowDoubleTapEventCallback? onRowDoubleTap) {
     _onRowDoubleTap = onRowDoubleTap;
+  }
+
+  void setOnRowSecondaryTap(PlutoOnRowSecondaryTapEventCallback? onRowSecondaryTap) {
+    _onRowSecondaryTap = onRowSecondaryTap;
   }
 
   void setCreateHeader(CreateHeaderCallBack? createHeader) {

--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -45,6 +45,8 @@ abstract class IGridState {
 
   void setOnRowChecked(PlutoOnRowCheckedEventCallback? onRowChecked);
 
+  void setOnRowDoubleTap(PlutoOnRowDoubleTapEventCallback? onDoubleTap);
+
   void setConfiguration(PlutoGridConfiguration configuration);
 
   void resetCurrentState({bool notify = true});
@@ -86,6 +88,10 @@ mixin GridState implements IPlutoGridState {
 
   PlutoOnRowCheckedEventCallback? _onRowChecked;
 
+  PlutoOnRowDoubleTapEventCallback? get onRowDoubleTap => _onRowDoubleTap;
+
+  PlutoOnRowDoubleTapEventCallback? _onRowDoubleTap;
+
   CreateHeaderCallBack? get createHeader => _createHeader;
 
   CreateHeaderCallBack? _createHeader;
@@ -118,6 +124,10 @@ mixin GridState implements IPlutoGridState {
 
   void setOnRowChecked(PlutoOnRowCheckedEventCallback? onRowChecked) {
     _onRowChecked = onRowChecked;
+  }
+
+  void setOnRowDoubleTap(PlutoOnRowDoubleTapEventCallback? onRowDoubleTap) {
+    _onRowDoubleTap = onRowDoubleTap;
   }
 
   void setCreateHeader(CreateHeaderCallBack? createHeader) {

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -14,6 +14,9 @@ typedef PlutoOnSelectedEventCallback = void Function(
 typedef PlutoOnRowCheckedEventCallback = void Function(
     PlutoGridOnRowCheckedEvent event);
 
+typedef PlutoOnRowDoubleTapEventCallback = void Function(
+    PlutoGridOnRowDoubleTapEvent event);
+
 typedef CreateHeaderCallBack = Widget Function(
     PlutoGridStateManager stateManager);
 
@@ -32,6 +35,8 @@ class PlutoGrid extends StatefulWidget {
   final PlutoOnSelectedEventCallback? onSelected;
 
   final PlutoOnRowCheckedEventCallback? onRowChecked;
+
+  final PlutoOnRowDoubleTapEventCallback? onRowDoubleTap;
 
   final CreateHeaderCallBack? createHeader;
 
@@ -55,6 +60,7 @@ class PlutoGrid extends StatefulWidget {
     this.onChanged,
     this.onSelected,
     this.onRowChecked,
+    this.onRowDoubleTap,
     this.createHeader,
     this.createFooter,
     this.configuration,
@@ -137,6 +143,7 @@ class _PlutoGridState extends State<PlutoGrid> {
       onChangedEventCallback: widget.onChanged,
       onSelectedEventCallback: widget.onSelected,
       onRowCheckedEventCallback: widget.onRowChecked,
+      onRowDoubleTapEventCallback: widget.onRowDoubleTap,
       createHeader: widget.createHeader,
       createFooter: widget.createFooter,
       configuration: widget.configuration,
@@ -481,6 +488,16 @@ abstract class PlutoGridOnRowCheckedEvent {
   PlutoGridOnRowCheckedEvent({
     this.row,
     this.isChecked,
+  });
+}
+
+class PlutoGridOnRowDoubleTapEvent {
+  final PlutoRow? row;
+  final PlutoCell? cell;
+
+  PlutoGridOnRowDoubleTapEvent({
+    this.row,
+    this.cell,
   });
 }
 

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -17,6 +17,9 @@ typedef PlutoOnRowCheckedEventCallback = void Function(
 typedef PlutoOnRowDoubleTapEventCallback = void Function(
     PlutoGridOnRowDoubleTapEvent event);
 
+typedef PlutoOnRowSecondaryTapEventCallback = void Function(
+    PlutoGridOnRowSecondaryTapEvent event);
+
 typedef CreateHeaderCallBack = Widget Function(
     PlutoGridStateManager stateManager);
 
@@ -37,6 +40,8 @@ class PlutoGrid extends StatefulWidget {
   final PlutoOnRowCheckedEventCallback? onRowChecked;
 
   final PlutoOnRowDoubleTapEventCallback? onRowDoubleTap;
+
+  final PlutoOnRowSecondaryTapEventCallback? onRowSecondaryTap;
 
   final CreateHeaderCallBack? createHeader;
 
@@ -61,6 +66,7 @@ class PlutoGrid extends StatefulWidget {
     this.onSelected,
     this.onRowChecked,
     this.onRowDoubleTap,
+    this.onRowSecondaryTap,
     this.createHeader,
     this.createFooter,
     this.configuration,
@@ -144,6 +150,7 @@ class _PlutoGridState extends State<PlutoGrid> {
       onSelectedEventCallback: widget.onSelected,
       onRowCheckedEventCallback: widget.onRowChecked,
       onRowDoubleTapEventCallback: widget.onRowDoubleTap,
+      onRowSecondaryTapEventCallback: widget.onRowSecondaryTap,
       createHeader: widget.createHeader,
       createFooter: widget.createFooter,
       configuration: widget.configuration,
@@ -498,6 +505,18 @@ class PlutoGridOnRowDoubleTapEvent {
   PlutoGridOnRowDoubleTapEvent({
     this.row,
     this.cell,
+  });
+}
+
+class PlutoGridOnRowSecondaryTapEvent {
+  final PlutoRow? row;
+  final PlutoCell? cell;
+  final Offset? offset;
+
+  PlutoGridOnRowSecondaryTapEvent({
+    this.row,
+    this.cell,
+    this.offset,
   });
 }
 

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -107,12 +107,17 @@ class _PlutoBaseCellState extends _PlutoBaseCellStateWithChangeKeepAlive {
         PlutoGridGestureType.onLongPressEnd, details.globalPosition);
   }
 
+  void _handleOnDoubleTap() {
+    _addGestureEvent(PlutoGridGestureType.onDoubleTap, Offset.zero);
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
 
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
+      onDoubleTap: _handleOnDoubleTap,
       onTapUp: _handleOnTapUp,
       onLongPressStart: _handleOnLongPressStart,
       onLongPressMoveUpdate: _handleOnLongPressMoveUpdate,

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -111,6 +111,10 @@ class _PlutoBaseCellState extends _PlutoBaseCellStateWithChangeKeepAlive {
     _addGestureEvent(PlutoGridGestureType.onDoubleTap, Offset.zero);
   }
 
+  void _handleOnSecondaryTap(TapDownDetails details) {
+    _addGestureEvent(PlutoGridGestureType.onSecondaryTap, details.globalPosition);
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -118,6 +122,7 @@ class _PlutoBaseCellState extends _PlutoBaseCellStateWithChangeKeepAlive {
     return GestureDetector(
       behavior: HitTestBehavior.translucent,
       onDoubleTap: _handleOnDoubleTap,
+      onSecondaryTapDown: _handleOnSecondaryTap,
       onTapUp: _handleOnTapUp,
       onLongPressStart: _handleOnLongPressStart,
       onLongPressMoveUpdate: _handleOnLongPressMoveUpdate,


### PR DESCRIPTION
This branch implements a row secondary tap handler.  (#229 )
It is based on the branch from Chuanbin-Wang, implementing double tap handling. 

There are some changes in example/lib/main.dart to allow right click events to be captured from the browser.
These may not be valid on non-browser platforms, though I included for testing.
It maybe best to remove these before merge.
I'm happy to update the branch if needed.