### PR TITLE
Optimize resize performance

### DIFF
--- a/demo/lib/screen/development_screen.dart
+++ b/demo/lib/screen/development_screen.dart
@@ -184,22 +184,26 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
     columnGroups = [
       PlutoColumnGroup(
         title: 'Expanded Column Group',
+        groupId: 'Expanded Column Group',
         fields: ['column1'],
         expandedColumn: true,
       ),
       PlutoColumnGroup(
         title: 'Group A',
+        groupId: 'Group A',
         children: [
-          PlutoColumnGroup(title: 'SubA', fields: ['column2']),
-          PlutoColumnGroup(title: 'SubB', fields: ['column3']),
+          PlutoColumnGroup(title: 'SubA', groupId: 'SubA', fields: ['column2']),
+          PlutoColumnGroup(title: 'SubB', groupId: 'SubB', fields: ['column3']),
         ],
       ),
       PlutoColumnGroup(
         title: 'Group B',
+        groupId: 'Group B',
         fields: ['column4', 'column5', 'column6'],
       ),
       PlutoColumnGroup(
         title: 'Group C',
+        groupId: 'Group C',
         fields: ['column7'],
       ),
     ];
@@ -233,7 +237,7 @@ class _DevelopmentScreenState extends State<DevelopmentScreen> {
           onLoaded: (PlutoGridOnLoadedEvent event) {
             stateManager = event.stateManager;
 
-            stateManager.setShowColumnFilter(true, notify: false);
+            stateManager.setShowColumnFilter(true);
 
             // stateManager!.setAutoEditing(true, notify: false);
           },
@@ -388,84 +392,78 @@ class _HeaderState extends State<_Header> {
 
   @override
   Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      scrollDirection: Axis.horizontal,
-      child: SizedBox(
-        height: widget.stateManager.headerHeight,
-        child: Wrap(
-          spacing: 10,
-          crossAxisAlignment: WrapCrossAlignment.center,
-          children: [
-            ElevatedButton(
-              child: const Text('Go Home'),
-              onPressed: () {
-                Navigator.pushNamed(context, HomeScreen.routeName);
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Go Empty'),
-              onPressed: () {
-                Navigator.pushNamed(context, EmptyScreen.routeName);
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Add 10'),
-              onPressed: () {
-                handleAddRowButton(count: 10);
-              },
-            ),
-            ElevatedButton(
-              child: const Text('Add 100 Rows'),
-              onPressed: () => handleAddRowButton(count: 100),
-            ),
-            ElevatedButton(
-              child: const Text('Add 100,000 Rows'),
-              onPressed: () => handleAddRowButton(count: 100000),
-            ),
-            ElevatedButton(
-              child: const Text('Remove Current Row'),
-              onPressed: handleRemoveCurrentRowButton,
-            ),
-            ElevatedButton(
-              child: const Text('Remove Selected Rows'),
-              onPressed: handleRemoveSelectedRowsButton,
-            ),
-            DropdownButtonHideUnderline(
-              child: DropdownButton(
-                value: gridSelectingMode,
-                items: PlutoGridStateManager.selectingModes
-                    .map<DropdownMenuItem<PlutoGridSelectingMode>>(
-                        (PlutoGridSelectingMode item) {
-                  final color = gridSelectingMode == item ? Colors.blue : null;
-
-                  return DropdownMenuItem<PlutoGridSelectingMode>(
-                    value: item,
-                    child: Text(
-                      item.toShortString(),
-                      style: TextStyle(color: color),
-                    ),
-                  );
-                }).toList(),
-                onChanged: (PlutoGridSelectingMode? mode) {
-                  setGridSelectingMode(mode);
-                },
-              ),
-            ),
-            ElevatedButton(
-              child: const Text('Toggle filter'),
-              onPressed: handleToggleColumnFilter,
-            ),
-            ElevatedButton(
-              child: const Text('Toggle group'),
-              onPressed: () {
-                widget.stateManager.setShowColumnGroups(
-                  !widget.stateManager.showColumnGroups,
-                );
-              },
-            ),
-          ],
+    return Wrap(
+      spacing: 10,
+      crossAxisAlignment: WrapCrossAlignment.center,
+      children: [
+        ElevatedButton(
+          child: const Text('Go Home'),
+          onPressed: () {
+            Navigator.pushNamed(context, HomeScreen.routeName);
+          },
         ),
-      ),
+        ElevatedButton(
+          child: const Text('Go Empty'),
+          onPressed: () {
+            Navigator.pushNamed(context, EmptyScreen.routeName);
+          },
+        ),
+        ElevatedButton(
+          child: const Text('Add 10'),
+          onPressed: () {
+            handleAddRowButton(count: 10);
+          },
+        ),
+        ElevatedButton(
+          child: const Text('Add 100 Rows'),
+          onPressed: () => handleAddRowButton(count: 100),
+        ),
+        ElevatedButton(
+          child: const Text('Add 100,000 Rows'),
+          onPressed: () => handleAddRowButton(count: 100000),
+        ),
+        ElevatedButton(
+          child: const Text('Remove Current Row'),
+          onPressed: handleRemoveCurrentRowButton,
+        ),
+        ElevatedButton(
+          child: const Text('Remove Selected Rows'),
+          onPressed: handleRemoveSelectedRowsButton,
+        ),
+        DropdownButtonHideUnderline(
+          child: DropdownButton(
+            value: gridSelectingMode,
+            items: PlutoGridStateManager.selectingModes
+                .map<DropdownMenuItem<PlutoGridSelectingMode>>(
+                    (PlutoGridSelectingMode item) {
+              final color = gridSelectingMode == item ? Colors.blue : null;
+
+              return DropdownMenuItem<PlutoGridSelectingMode>(
+                value: item,
+                child: Text(
+                  item.toShortString(),
+                  style: TextStyle(color: color),
+                ),
+              );
+            }).toList(),
+            onChanged: (PlutoGridSelectingMode? mode) {
+              setGridSelectingMode(mode);
+            },
+          ),
+        ),
+        ElevatedButton(
+          child: const Text('Toggle filter'),
+          onPressed: handleToggleColumnFilter,
+        ),
+        ElevatedButton(
+          child: const Text('Toggle group'),
+          onPressed: () {
+            widget.stateManager.setShowColumnGroups(
+              !widget.stateManager.showColumnGroups,
+            );
+          },
+        ),
+      ],
     );
   }
 }

--- a/demo/lib/screen/feature/add_and_remove_column_row_screen.dart
+++ b/demo/lib/screen/feature/add_and_remove_column_row_screen.dart
@@ -97,8 +97,9 @@ class _AddAndRemoveColumnRowScreenState
     ]);
 
     columnGroups.addAll([
-      PlutoColumnGroup(title: 'User', fields: ['id', 'name']),
+      PlutoColumnGroup(groupId: 'User', title: 'User', fields: ['id', 'name']),
       PlutoColumnGroup(
+        groupId: 'Status',
         title: 'Status',
         fields: ['status'],
         expandedColumn: true,

--- a/demo/lib/screen/feature/column_group_screen.dart
+++ b/demo/lib/screen/feature/column_group_screen.dart
@@ -82,25 +82,31 @@ class _ColumnGroupScreenState extends State<ColumnGroupScreen> {
 
     columnGroups.addAll([
       PlutoColumnGroup(
+        groupId: 'Expanded',
         title: 'Expanded',
         fields: ['column1'],
         expandedColumn: true,
       ),
       PlutoColumnGroup(
+        groupId: 'Group A',
         title: 'Group A',
         children: [
           PlutoColumnGroup(
+            groupId: 'A - 1',
             title: 'A - 1',
             fields: ['column2', 'column3'],
           ),
           PlutoColumnGroup(
+            groupId: 'A - 2',
             title: 'A - 2',
             children: [
               PlutoColumnGroup(
+                groupId: 'A - 2 - 1',
                 title: 'A - 2 - 1',
                 fields: ['column4'],
               ),
               PlutoColumnGroup(
+                groupId: 'A - 2 - 2',
                 title: 'A - 2 - 2',
                 fields: ['column5'],
               ),
@@ -109,25 +115,31 @@ class _ColumnGroupScreenState extends State<ColumnGroupScreen> {
         ],
       ),
       PlutoColumnGroup(
+        groupId: 'Group B',
         title: 'Group B',
         children: [
           PlutoColumnGroup(
+            groupId: 'B - 1',
             title: 'B - 1',
             children: [
               PlutoColumnGroup(
+                groupId: 'B - 1 - 1',
                 title: 'B - 1 - 1',
                 children: [
                   PlutoColumnGroup(
+                    groupId: 'B - 1 - 1 - 1',
                     title: 'B - 1 - 1 - 1',
                     fields: ['column6'],
                   ),
                   PlutoColumnGroup(
+                    groupId: 'B - 1 - 1 - 2',
                     title: 'B - 1 - 1 - 2',
                     fields: ['column7'],
                   ),
                 ],
               ),
               PlutoColumnGroup(
+                groupId: 'Expanded',
                 title: 'Expanded',
                 fields: ['column8'],
                 expandedColumn: true,

--- a/lib/src/extends/pluto_state_with_change.dart
+++ b/lib/src/extends/pluto_state_with_change.dart
@@ -49,7 +49,11 @@ abstract class PlutoStateWithChange<T extends PlutoStatefulWidget>
 
   void resetState(_ResetStateCallback callback) {
     callback(_update);
-    if (mounted && _initialized && _changed) {
+    // it may have not been layouted yet.
+    if (mounted &&
+        _initialized &&
+        _changed &&
+        widget.stateManager.maxWidth != null) {
       _changed = false;
       _statefulElement?.markNeedsBuild();
     }

--- a/lib/src/helper/pluto_column_group_helper.dart
+++ b/lib/src/helper/pluto_column_group_helper.dart
@@ -69,6 +69,7 @@ class PlutoColumnGroupHelper {
             columnGroupList: columnGroupList,
           ) ??
           PlutoColumnGroup(
+            groupId: field,
             title: field,
             fields: [field],
             expandedColumn: true,

--- a/lib/src/manager/state/scroll_state.dart
+++ b/lib/src/manager/state/scroll_state.dart
@@ -194,11 +194,11 @@ mixin ScrollState implements IPlutoGridState {
   /// when resizing the screen.
   @override
   void resetScrollToZero() {
-    if ((scroll?.bodyRowsVertical?.offset ?? 0) <= 0) {
+    if ((scroll?.bodyRowsVertical?.offset ?? 0) < 0) {
       scroll?.bodyRowsVertical?.jumpTo(0);
     }
 
-    if ((scroll?.bodyRowsHorizontal?.offset ?? 0) <= 0) {
+    if ((scroll?.bodyRowsHorizontal?.offset ?? 0)  <  0) {
       scroll?.bodyRowsHorizontal?.jumpTo(0);
     }
   }

--- a/lib/src/model/pluto_column_group.dart
+++ b/lib/src/model/pluto_column_group.dart
@@ -35,8 +35,12 @@ class PlutoColumnGroup {
   /// The group title is not shown.
   final bool? expandedColumn;
 
+  /// a unique name to represent the group
+  String groupId;
+
   PlutoColumnGroup({
     required this.title,
+    required this.groupId,
     this.fields,
     this.children,
     this.titlePadding,
@@ -49,15 +53,15 @@ class PlutoColumnGroup {
         assert(expandedColumn == true
             ? fields?.length == 1 && children == null
             : true),
-        _key = UniqueKey() {
+        _key = ValueKey(groupId) {
     hasFields = fields != null;
 
     hasChildren = !hasFields;
   }
 
-  Key get key => _key;
+  ValueKey get key => _key;
 
-  final Key _key;
+  final ValueKey _key;
 
   late final bool hasFields;
 
@@ -71,7 +75,13 @@ class PlutoColumnGroupPair {
   PlutoColumnGroupPair({
     required this.group,
     required this.columns,
-  }) : _key = ObjectKey({group.key: columns});
+  }) :
+        // a unique reproducable key
+        _key = ValueKey(group.key.value.toString() +
+            columns.fold(
+                "",
+                (previousValue, element) =>
+                    previousValue + "-" + element.field));
 
   Key get key => _key;
 

--- a/lib/src/plugin/pluto_pagination.dart
+++ b/lib/src/plugin/pluto_pagination.dart
@@ -174,65 +174,67 @@ class _PlutoPaginationState extends _PlutoPaginationStateWithChange {
     return LayoutBuilder(
       builder: (layoutContext, size) {
         _maxWidth = size.maxWidth;
-
         final Color _iconColor = widget.stateManager.configuration!.iconColor;
-
         final Color _disabledIconColor =
             widget.stateManager.configuration!.disabledIconColor;
-
-        return Center(
-          child: SingleChildScrollView(
-            scrollDirection: Axis.horizontal,
-            child: Padding(
-              padding: const EdgeInsets.only(top: 3),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  IconButton(
-                    onPressed: _isFirstPage ? null : _firstPage,
-                    icon: const Icon(Icons.first_page),
-                    color: _iconColor,
-                    disabledColor: _disabledIconColor,
-                    splashRadius: _iconSplashRadius,
-                    mouseCursor: _isFirstPage
-                        ? SystemMouseCursors.basic
-                        : SystemMouseCursors.click,
-                  ),
-                  IconButton(
-                    onPressed: _isFirstPage ? null : _beforePage,
-                    icon: const Icon(Icons.navigate_before),
-                    color: _iconColor,
-                    disabledColor: _disabledIconColor,
-                    splashRadius: _iconSplashRadius,
-                    mouseCursor: _isFirstPage
-                        ? SystemMouseCursors.basic
-                        : SystemMouseCursors.click,
-                  ),
-                  ..._pageNumbers.map(_makeNumberButton).toList(),
-                  IconButton(
-                    onPressed: _isLastPage ? null : _nextPage,
-                    icon: const Icon(Icons.navigate_next),
-                    color: _iconColor,
-                    disabledColor: _disabledIconColor,
-                    splashRadius: _iconSplashRadius,
-                    mouseCursor: _isLastPage
-                        ? SystemMouseCursors.basic
-                        : SystemMouseCursors.click,
-                  ),
-                  IconButton(
-                    onPressed: _isLastPage ? null : _lastPage,
-                    icon: const Icon(Icons.last_page),
-                    color: _iconColor,
-                    disabledColor: _disabledIconColor,
-                    splashRadius: _iconSplashRadius,
-                    mouseCursor: _isLastPage
-                        ? SystemMouseCursors.basic
-                        : SystemMouseCursors.click,
-                  ),
-                ],
+        // can't center using center, it'll take all max width and max height
+        return Row(
+          mainAxisSize: MainAxisSize.max,
+          mainAxisAlignment: MainAxisAlignment.spaceAround,
+          children: [
+            SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 3),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    IconButton(
+                      onPressed: _isFirstPage ? null : _firstPage,
+                      icon: const Icon(Icons.first_page),
+                      color: _iconColor,
+                      disabledColor: _disabledIconColor,
+                      splashRadius: _iconSplashRadius,
+                      mouseCursor: _isFirstPage
+                          ? SystemMouseCursors.basic
+                          : SystemMouseCursors.click,
+                    ),
+                    IconButton(
+                      onPressed: _isFirstPage ? null : _beforePage,
+                      icon: const Icon(Icons.navigate_before),
+                      color: _iconColor,
+                      disabledColor: _disabledIconColor,
+                      splashRadius: _iconSplashRadius,
+                      mouseCursor: _isFirstPage
+                          ? SystemMouseCursors.basic
+                          : SystemMouseCursors.click,
+                    ),
+                    ..._pageNumbers.map(_makeNumberButton).toList(),
+                    IconButton(
+                      onPressed: _isLastPage ? null : _nextPage,
+                      icon: const Icon(Icons.navigate_next),
+                      color: _iconColor,
+                      disabledColor: _disabledIconColor,
+                      splashRadius: _iconSplashRadius,
+                      mouseCursor: _isLastPage
+                          ? SystemMouseCursors.basic
+                          : SystemMouseCursors.click,
+                    ),
+                    IconButton(
+                      onPressed: _isLastPage ? null : _lastPage,
+                      icon: const Icon(Icons.last_page),
+                      color: _iconColor,
+                      disabledColor: _disabledIconColor,
+                      splashRadius: _iconSplashRadius,
+                      mouseCursor: _isLastPage
+                          ? SystemMouseCursors.basic
+                          : SystemMouseCursors.click,
+                    ),
+                  ],
+                ),
               ),
-            ),
-          ),
+            )
+          ],
         );
       },
     );

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -315,12 +315,6 @@ class _PlutoGridState extends State<PlutoGrid> {
     return _keyManager!.eventResult.consume(KeyEventResult.handled);
   }
 
-  void _setLayout(BoxConstraints size) {
-    _stateManager.setLayout(size);
-
-    _resetState();
-  }
-
   void _resetState() {
     _showFrozenColumn = _stateManager.showFrozenColumn;
 
@@ -438,15 +432,18 @@ class _PlutoGridState extends State<PlutoGrid> {
                   child: _footer!,
                 ),
               if (_stateManager.showLoading)
-                PlutoLoading(
-                  backgroundColor:
-                      _stateManager.configuration!.gridBackgroundColor,
-                  indicatorColor:
-                      _stateManager.configuration!.cellTextStyle.color,
-                  indicatorText:
-                      _stateManager.configuration!.localeText.loadingText,
-                  indicatorSize:
-                      _stateManager.configuration!.cellTextStyle.fontSize,
+                LayoutId(
+                  id: _StackName.loading,
+                  child: PlutoLoading(
+                    backgroundColor:
+                        _stateManager.configuration!.gridBackgroundColor,
+                    indicatorColor:
+                        _stateManager.configuration!.cellTextStyle.color,
+                    indicatorText:
+                        _stateManager.configuration!.localeText.loadingText,
+                    indicatorSize:
+                        _stateManager.configuration!.cellTextStyle.fontSize,
+                  ),
                 ),
             ],
           ),
@@ -588,6 +585,9 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
           _StackName.bodyRows, BoxConstraints.tight(Size(width, height)));
       positionChild(
           _StackName.bodyRows, Offset(bodyLeftOffset, bodyRowsTopOffset));
+    }
+    if (hasChild(_StackName.loading)) {
+      layoutChild(_StackName.loading, BoxConstraints.tight(totalSize));
     }
   }
 

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1,6 +1,7 @@
 import 'dart:ui';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show Intl;
 import 'package:linked_scroll_controller/linked_scroll_controller.dart';
@@ -129,140 +130,6 @@ class _PlutoGridState extends State<PlutoGrid> {
     _StackName.footerDivider: UniqueKey(),
     _StackName.loading: UniqueKey(),
   };
-
-  get _headerStack => Positioned.fill(
-        bottom: _stateManager.headerBottomOffset,
-        child: _header!,
-        key: _stackKeys[_StackName.header],
-      );
-
-  get _headerDividerStack => Positioned(
-        top: _stateManager.headerHeight,
-        left: 0,
-        right: 0,
-        child: PlutoShadowLine(
-          axis: Axis.horizontal,
-          color: _stateManager.configuration!.gridBorderColor,
-          shadow: _stateManager.configuration!.enableGridBorderShadow,
-        ),
-        key: _stackKeys[_StackName.headerDivider],
-      );
-
-  get _leftFrozenColumnsStack => Positioned.fill(
-        top: _stateManager.headerHeight,
-        right: _stateManager.leftFrozenRightOffset,
-        bottom: _stateManager.columnBottomOffset,
-        child: PlutoLeftFrozenColumns(_stateManager),
-        key: _stackKeys[_StackName.leftFrozenColumns],
-      );
-
-  get _leftFrozenRowsStack => Positioned.fill(
-        top: _stateManager.rowsTopOffset,
-        right: _stateManager.leftFrozenRightOffset,
-        bottom: _stateManager.footerHeight,
-        child: PlutoLeftFrozenRows(_stateManager),
-        key: _stackKeys[_StackName.leftFrozenRows],
-      );
-
-  get _bodyColumnsStack => Positioned.fill(
-        top: _stateManager.headerHeight,
-        left: _bodyLeftOffset,
-        right: _bodyRightOffset,
-        bottom: _stateManager.columnBottomOffset,
-        child: PlutoBodyColumns(_stateManager),
-        key: _stackKeys[_StackName.bodyColumns],
-      );
-
-  get _bodyRowsStack => Positioned.fill(
-        top: _stateManager.rowsTopOffset,
-        left: _bodyLeftOffset,
-        right: _bodyRightOffset,
-        bottom: _stateManager.footerHeight,
-        child: PlutoBodyRows(_stateManager),
-        key: _stackKeys[_StackName.bodyRows],
-      );
-
-  get _rightFrozenColumnsStack => Positioned.fill(
-        top: _stateManager.headerHeight,
-        left: _rightFrozenLeftOffset,
-        bottom: _stateManager.columnBottomOffset,
-        child: PlutoRightFrozenColumns(_stateManager),
-        key: _stackKeys[_StackName.rightFrozenColumns],
-      );
-
-  get _rightFrozenRowsStack => Positioned.fill(
-        top: _stateManager.rowsTopOffset,
-        left: _rightFrozenLeftOffset,
-        bottom: _stateManager.footerHeight,
-        child: PlutoRightFrozenRows(_stateManager),
-        key: _stackKeys[_StackName.rightFrozenRows],
-      );
-
-  get _leftFrozenDividerStack => Positioned(
-        top: _stateManager.headerHeight,
-        left: _bodyLeftOffset! - PlutoGridSettings.gridBorderWidth,
-        bottom: _stateManager.footerHeight,
-        child: PlutoShadowLine(
-          axis: Axis.vertical,
-          color: _stateManager.configuration!.gridBorderColor,
-          shadow: _stateManager.configuration!.enableGridBorderShadow,
-        ),
-        key: _stackKeys[_StackName.leftFrozenDivider],
-      );
-
-  get _rightFrozenDividerStack => Positioned(
-        top: _stateManager.headerHeight,
-        left: _rightFrozenLeftOffset! - PlutoGridSettings.gridBorderWidth,
-        bottom: _stateManager.footerHeight,
-        child: PlutoShadowLine(
-          axis: Axis.vertical,
-          reverse: true,
-          color: _stateManager.configuration!.gridBorderColor,
-          shadow: _stateManager.configuration!.enableGridBorderShadow,
-        ),
-        key: _stackKeys[_StackName.rightFrozenDivider],
-      );
-
-  get _columnRowDividerStack => Positioned(
-        top: _stateManager.rowsTopOffset - PlutoGridSettings.gridBorderWidth,
-        left: 0,
-        right: 0,
-        child: PlutoShadowLine(
-          axis: Axis.horizontal,
-          color: _stateManager.configuration!.gridBorderColor,
-          shadow: _stateManager.configuration!.enableGridBorderShadow,
-        ),
-        key: _stackKeys[_StackName.columnRowDivider],
-      );
-
-  get _footerDividerStack => Positioned(
-        top: _stateManager.footerTopOffset,
-        left: 0,
-        right: 0,
-        child: PlutoShadowLine(
-          axis: Axis.horizontal,
-          reverse: true,
-          color: _stateManager.configuration!.gridBorderColor,
-          shadow: _stateManager.configuration!.enableGridBorderShadow,
-        ),
-        key: _stackKeys[_StackName.footerDivider],
-      );
-
-  get _footerStack => Positioned.fill(
-        top: _stateManager.footerTopOffset,
-        child: _footer!,
-        key: _stackKeys[_StackName.footer],
-      );
-
-  get _loadingStack => Positioned.fill(
-        child: PlutoLoading(
-          backgroundColor: _stateManager.configuration!.gridBackgroundColor,
-          indicatorColor: _stateManager.configuration!.cellTextStyle.color,
-          indicatorText: _stateManager.configuration!.localeText.loadingText,
-          indicatorSize: _stateManager.configuration!.cellTextStyle.fontSize,
-        ),
-        key: _stackKeys[_StackName.loading],
-      );
 
   @override
   void dispose() {
@@ -415,7 +282,10 @@ class _PlutoGridState extends State<PlutoGrid> {
         _showColumnGroups != _stateManager.showColumnGroups ||
         _showColumnFilter != _stateManager.showColumnFilter ||
         _showLoading != _stateManager.showLoading) {
-      setState(_resetState);
+      // it has been layouted
+      if (_stateManager.maxWidth != null) {
+        setState(_resetState);
+      }
     }
   }
 
@@ -456,66 +326,22 @@ class _PlutoGridState extends State<PlutoGrid> {
 
     _hasLeftFrozenColumns = _stateManager.hasLeftFrozenColumns;
 
-    _bodyLeftOffset = _stateManager.bodyLeftOffset;
-
-    _bodyRightOffset = _stateManager.bodyRightOffset;
-
     _hasRightFrozenColumns = _stateManager.hasRightFrozenColumns;
-
-    _rightFrozenLeftOffset = _stateManager.rightFrozenLeftOffset;
 
     _showColumnGroups = _stateManager.showColumnGroups;
 
     _showColumnFilter = _stateManager.showColumnFilter;
 
     _showLoading = _stateManager.showLoading;
-  }
 
-  Widget _builder(BuildContext ctx, BoxConstraints size) {
-    _setLayout(size);
+    // it may be called before layout
+    if (_stateManager.maxWidth != null) {
+      _bodyLeftOffset = _stateManager.bodyLeftOffset;
 
-    if (_stateManager.keepFocus) {
-      _gridFocusNode?.requestFocus();
+      _bodyRightOffset = _stateManager.bodyRightOffset;
+
+      _rightFrozenLeftOffset = _stateManager.rightFrozenLeftOffset;
     }
-
-    final List<Widget> stack = [];
-
-    if (_stateManager.showHeader) {
-      stack.add(_headerStack);
-      stack.add(_headerDividerStack);
-    }
-
-    if (_showFrozenColumn! && _hasLeftFrozenColumns!) {
-      stack.add(_leftFrozenColumnsStack);
-      stack.add(_leftFrozenRowsStack);
-      stack.add(_leftFrozenDividerStack);
-    }
-
-    stack.add(_bodyColumnsStack);
-    stack.add(_bodyRowsStack);
-    stack.add(_columnRowDividerStack);
-
-    if (_showFrozenColumn! && _hasRightFrozenColumns!) {
-      stack.add(_rightFrozenColumnsStack);
-      stack.add(_rightFrozenRowsStack);
-      stack.add(_rightFrozenDividerStack);
-    }
-
-    if (_stateManager.showFooter) {
-      stack.add(_footerStack);
-      stack.add(_footerDividerStack);
-    }
-
-    if (_stateManager.showLoading) {
-      stack.add(_loadingStack);
-    }
-
-    return _GridContainer(
-      stateManager: _stateManager,
-      child: Stack(
-        children: stack,
-      ),
-    );
   }
 
   @override
@@ -524,9 +350,250 @@ class _PlutoGridState extends State<PlutoGrid> {
       onFocusChange: _stateManager.setKeepFocus,
       onKey: _handleGridFocusOnKey,
       child: SafeArea(
-        child: LayoutBuilder(key: _stateManager.gridKey, builder: _builder),
+        child: _GridContainer(
+          stateManager: _stateManager,
+          child: CustomMultiChildLayout(
+            key: _stateManager.gridKey,
+            delegate: PlutoGridLayoutDelegate(_stateManager),
+            children: [
+              LayoutId(
+                  id: _StackName.bodyColumns,
+                  child: PlutoBodyColumns(_stateManager)),
+              LayoutId(
+                  id: _StackName.bodyRows, child: PlutoBodyRows(_stateManager)),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasLeftFrozenColumns)
+                LayoutId(
+                    id: _StackName.leftFrozenColumns,
+                    child: PlutoLeftFrozenColumns(_stateManager)),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasLeftFrozenColumns)
+                LayoutId(
+                    id: _StackName.leftFrozenRows,
+                    child: PlutoLeftFrozenRows(_stateManager)),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasRightFrozenColumns)
+                LayoutId(
+                    id: _StackName.rightFrozenColumns,
+                    child: PlutoRightFrozenColumns(_stateManager)),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasRightFrozenColumns)
+                LayoutId(
+                    id: _StackName.rightFrozenRows,
+                    child: PlutoRightFrozenRows(_stateManager)),
+              LayoutId(
+                id: _StackName.columnRowDivider,
+                child: PlutoShadowLine(
+                  axis: Axis.horizontal,
+                  color: _stateManager.configuration!.gridBorderColor,
+                  shadow: _stateManager.configuration!.enableGridBorderShadow,
+                ),
+              ),
+              if (_stateManager.showHeader)
+                LayoutId(
+                  id: _StackName.headerDivider,
+                  child: PlutoShadowLine(
+                    axis: Axis.horizontal,
+                    color: _stateManager.configuration!.gridBorderColor,
+                    shadow: _stateManager.configuration!.enableGridBorderShadow,
+                  ),
+                ),
+              if (_stateManager.showFooter)
+                LayoutId(
+                  id: _StackName.footerDivider,
+                  child: PlutoShadowLine(
+                    axis: Axis.horizontal,
+                    color: _stateManager.configuration!.gridBorderColor,
+                    shadow: _stateManager.configuration!.enableGridBorderShadow,
+                  ),
+                ),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasLeftFrozenColumns)
+                LayoutId(
+                    id: _StackName.leftFrozenDivider,
+                    child: PlutoShadowLine(
+                      axis: Axis.vertical,
+                      color: _stateManager.configuration!.gridBorderColor,
+                      shadow:
+                          _stateManager.configuration!.enableGridBorderShadow,
+                    )),
+              if (_stateManager.showFrozenColumn &&
+                  _stateManager.hasRightFrozenColumns)
+                LayoutId(
+                    id: _StackName.rightFrozenDivider,
+                    child: PlutoShadowLine(
+                      axis: Axis.vertical,
+                      color: _stateManager.configuration!.gridBorderColor,
+                      shadow:
+                          _stateManager.configuration!.enableGridBorderShadow,
+                    )),
+              if (_stateManager.showHeader)
+                LayoutId(
+                  id: _StackName.header,
+                  child: _header!,
+                ),
+              if (_stateManager.showFooter)
+                LayoutId(
+                  id: _StackName.footer,
+                  child: _footer!,
+                ),
+              if (_stateManager.showLoading)
+                PlutoLoading(
+                  backgroundColor:
+                      _stateManager.configuration!.gridBackgroundColor,
+                  indicatorColor:
+                      _stateManager.configuration!.cellTextStyle.color,
+                  indicatorText:
+                      _stateManager.configuration!.localeText.loadingText,
+                  indicatorSize:
+                      _stateManager.configuration!.cellTextStyle.fontSize,
+                ),
+            ],
+          ),
+        ),
       ),
     );
+  }
+}
+
+class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
+  final PlutoGridStateManager _stateManager;
+
+  PlutoGridLayoutDelegate(this._stateManager)
+      : super(relayout: _stateManager.resizingChangeNotifier);
+
+  @override
+  void performLayout(Size totalSize) {
+    if (_stateManager.showFrozenColumn !=
+        _stateManager.shouldShowFrozenColumns(totalSize.width)) {
+      _stateManager.notifyListenersOnPostFrame();
+    }
+    _stateManager.setLayout(BoxConstraints.tight(totalSize));
+    double bodyRowsTopOffset = 0;
+    double bodyRowsBottomOffset = 0;
+    double columnsTopOffset = 0;
+    double bodyLeftOffset = 0;
+    double bodyRightOffset = 0;
+    // first layout header and footer and see what remains for the scrolling part
+    if (hasChild(_StackName.header)) {
+      // maximum 40% of the height
+      var s = layoutChild(
+          _StackName.header,
+          BoxConstraints.loose(
+              Size(totalSize.width, totalSize.height / 100 * 40)));
+      _stateManager.headerHeight = s.height;
+      bodyRowsTopOffset += s.height;
+      columnsTopOffset += s.height;
+    }
+    if (hasChild(_StackName.headerDivider)) {
+      var s = layoutChild(
+          _StackName.headerDivider,
+          BoxConstraints.tight(
+              Size(totalSize.width, PlutoGridSettings.gridBorderWidth)));
+      positionChild(_StackName.headerDivider, Offset(0, columnsTopOffset));
+      bodyRowsTopOffset += s.height;
+      columnsTopOffset += s.height;
+    }
+    if (hasChild(_StackName.footer)) {
+      // maximum 40% of the height
+      var s = layoutChild(_StackName.footer, BoxConstraints.loose(totalSize));
+      _stateManager.footerHeight = s.height;
+      bodyRowsBottomOffset += s.height;
+      positionChild(_StackName.footer,
+          Offset(0, totalSize.height - bodyRowsBottomOffset));
+      // columnsTopOffset += s.height;
+    }
+    if (hasChild(_StackName.footerDivider)) {
+      var s = layoutChild(
+          _StackName.footerDivider,
+          BoxConstraints.tight(
+              Size(totalSize.width, PlutoGridSettings.gridBorderWidth)));
+      positionChild(_StackName.footerDivider,
+          Offset(0, totalSize.height - bodyRowsBottomOffset));
+      // bodyRowsBottomOffset += s.height;
+      // columnsTopOffset += s.height;
+    }
+
+    // now layout columns of frozen sides and see what remains for the body width
+    if (hasChild(_StackName.leftFrozenColumns)) {
+      var s = layoutChild(
+          _StackName.leftFrozenColumns, BoxConstraints.loose(totalSize));
+      positionChild(_StackName.leftFrozenColumns, Offset(0, columnsTopOffset));
+      bodyLeftOffset = s.width;
+    }
+    if (hasChild(_StackName.leftFrozenDivider)) {
+      var s = layoutChild(
+          _StackName.leftFrozenDivider,
+          BoxConstraints.tight(Size(PlutoGridSettings.gridBorderWidth,
+              totalSize.height - columnsTopOffset - bodyRowsBottomOffset)));
+      positionChild(_StackName.leftFrozenDivider,
+          Offset(bodyLeftOffset, columnsTopOffset));
+      bodyLeftOffset += s.width;
+    }
+    if (hasChild(_StackName.rightFrozenColumns)) {
+      var s = layoutChild(
+          _StackName.rightFrozenColumns, BoxConstraints.loose(totalSize));
+      positionChild(_StackName.rightFrozenColumns,
+          Offset(totalSize.width - s.width, columnsTopOffset));
+      bodyRightOffset = s.width;
+    }
+    if (hasChild(_StackName.rightFrozenDivider)) {
+      var s = layoutChild(
+          _StackName.rightFrozenDivider,
+          BoxConstraints.tight(Size(PlutoGridSettings.gridBorderWidth,
+              totalSize.height - columnsTopOffset - bodyRowsBottomOffset)));
+      positionChild(_StackName.rightFrozenDivider,
+          Offset(totalSize.width - bodyRightOffset, columnsTopOffset));
+      bodyRightOffset += s.width;
+    }
+    if (hasChild(_StackName.bodyColumns)) {
+      var s = layoutChild(
+          _StackName.bodyColumns,
+          BoxConstraints.loose(Size(
+              totalSize.width - bodyLeftOffset - bodyRightOffset,
+              totalSize.height)));
+      positionChild(
+          _StackName.bodyColumns, Offset(bodyLeftOffset, columnsTopOffset));
+      bodyRowsTopOffset += s.height;
+    }
+
+    // layout rows
+    if (hasChild(_StackName.columnRowDivider)) {
+      var s = layoutChild(
+          _StackName.columnRowDivider,
+          BoxConstraints.tight(
+              Size(totalSize.width, PlutoGridSettings.gridBorderWidth)));
+      positionChild(_StackName.columnRowDivider, Offset(0, bodyRowsTopOffset));
+      bodyRowsTopOffset += s.height;
+    }
+    if (hasChild(_StackName.leftFrozenRows)) {
+      layoutChild(
+          _StackName.leftFrozenRows,
+          BoxConstraints.loose(Size(bodyLeftOffset,
+              totalSize.height - bodyRowsTopOffset - bodyRowsBottomOffset)));
+      positionChild(_StackName.leftFrozenRows, Offset(0, bodyRowsTopOffset));
+    }
+    if (hasChild(_StackName.rightFrozenRows)) {
+      layoutChild(
+          _StackName.rightFrozenRows,
+          BoxConstraints.loose(Size(bodyRightOffset,
+              totalSize.height - bodyRowsTopOffset - bodyRowsBottomOffset)));
+      positionChild(_StackName.rightFrozenRows,
+          Offset(totalSize.width - bodyRightOffset, bodyRowsTopOffset));
+    }
+    if (hasChild(_StackName.bodyRows)) {
+      var height = totalSize.height - bodyRowsTopOffset - bodyRowsBottomOffset;
+      var width = totalSize.width - bodyLeftOffset - bodyRightOffset;
+      layoutChild(
+          _StackName.bodyRows, BoxConstraints.tight(Size(width, height)));
+      positionChild(
+          _StackName.bodyRows, Offset(bodyLeftOffset, bodyRowsTopOffset));
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) {
+    return true;
   }
 }
 
@@ -622,6 +689,7 @@ class PlutoGridOnSelectedEvent {
 
 abstract class PlutoGridOnRowCheckedEvent {
   bool get isAll => runtimeType == PlutoGridOnRowCheckedAllEvent;
+
   bool get isRow => runtimeType == PlutoGridOnRowCheckedOneEvent;
 
   final PlutoRow? row;

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -239,7 +239,6 @@ class _PlutoColumnFilterState extends _PlutoColumnFilterStateWithChange {
     final configuration = widget.stateManager.configuration!;
 
     return Container(
-      width: widget.column.width,
       height: widget.stateManager.columnFilterHeight,
       padding: EdgeInsets.symmetric(horizontal: _padding),
       decoration: BoxDecoration(
@@ -254,30 +253,25 @@ class _PlutoColumnFilterState extends _PlutoColumnFilterStateWithChange {
               : BorderSide.none,
         ),
       ),
-      child: Align(
-        alignment: Alignment.center,
-        child: Stack(
-          children: [
-            TextField(
-              focusNode: _focusNode,
-              controller: _controller,
-              enabled: _enabled,
-              style: configuration.cellTextStyle,
-              onTap: _handleOnTap,
-              onChanged: _handleOnChanged,
-              onEditingComplete: _handleOnEditingComplete,
-              decoration: InputDecoration(
-                hintText: _enabled! ? widget.column.defaultFilter.title : '',
-                isDense: true,
-                filled: true,
-                fillColor: _textFieldColor,
-                border: _border,
-                enabledBorder: _border,
-                focusedBorder: _enabledBorder,
-                contentPadding: const EdgeInsets.symmetric(vertical: 5),
-              ),
-            ),
-          ],
+      child: Center(
+        child: TextField(
+          focusNode: _focusNode,
+          controller: _controller,
+          enabled: _enabled,
+          style: configuration.cellTextStyle,
+          onTap: _handleOnTap,
+          onChanged: _handleOnChanged,
+          onEditingComplete: _handleOnEditingComplete,
+          decoration: InputDecoration(
+            hintText: _enabled! ? widget.column.defaultFilter.title : '',
+            isDense: true,
+            filled: true,
+            fillColor: _textFieldColor,
+            border: _border,
+            enabledBorder: _border,
+            focusedBorder: _enabledBorder,
+            contentPadding: const EdgeInsets.symmetric(vertical: 5),
+          ),
         ),
       ),
     );

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -64,6 +64,7 @@ class _PlutoColumnTitleState extends _PlutoColumnTitleStateWithChange {
         break;
       case PlutoGridColumnMenuItem.autoFit:
         widget.stateManager.autoFitColumn(context, widget.column);
+        widget.stateManager.resizingChangeNotifier.notifyListeners();
         break;
       case PlutoGridColumnMenuItem.hideColumn:
         widget.stateManager.hideColumn(widget.column.key, true);
@@ -105,9 +106,10 @@ class _PlutoColumnTitleState extends _PlutoColumnTitleStateWithChange {
     widget.stateManager.resizeColumn(
       widget.column,
       moveOffset,
+      notify: false,
       checkScroll: false,
     );
-
+    widget.stateManager.resizingChangeNotifier.notifyListeners();
     widget.stateManager.scrollByDirection(
       PlutoMoveDirection.right,
       widget.stateManager.isInvalidHorizontalScroll
@@ -168,6 +170,8 @@ class _PlutoColumnTitleState extends _PlutoColumnTitleStateWithChange {
     return Stack(
       children: [
         Positioned(
+          left: 0,
+          right: 0,
           child: widget.column.enableColumnDrag
               ? _BuildDraggableWidget(
                   stateManager: widget.stateManager,

--- a/lib/src/ui/pluto_base_column.dart
+++ b/lib/src/ui/pluto_base_column.dart
@@ -36,18 +36,38 @@ abstract class _PlutoBaseColumnStateWithChange
 
 class _PlutoBaseColumnState extends _PlutoBaseColumnStateWithChange {
   @override
+  void initState() {
+    super.initState();
+    _showColumnFilter = widget.stateManager.showColumnFilter;
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Column(
+    return Stack(
+      fit: StackFit.expand,
       children: [
-        PlutoColumnTitle(
-          stateManager: widget.stateManager,
-          column: widget.column,
-          height: widget.columnTitleHeight ?? widget.stateManager.columnHeight,
-        ),
-        if (_showColumnFilter!)
-          PlutoColumnFilter(
+        Positioned(
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom:
+              _showColumnFilter! ? widget.stateManager.columnFilterHeight : 0,
+          child: PlutoColumnTitle(
             stateManager: widget.stateManager,
             column: widget.column,
+            height:
+                widget.columnTitleHeight ?? widget.stateManager.columnHeight,
+          ),
+        ),
+        if (_showColumnFilter!)
+          Positioned(
+            bottom: 0,
+            right: 0,
+            left: 0,
+            child: PlutoColumnFilter(
+              stateManager: widget.stateManager,
+              column: widget.column,
+            ),
           ),
       ],
     );

--- a/lib/src/ui/pluto_base_column_group.dart
+++ b/lib/src/ui/pluto_base_column_group.dart
@@ -18,27 +18,30 @@ class PlutoBaseColumnGroup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return columnGroup.group.expandedColumn == true
-        ? _ExpandedColumn(
+    if (columnGroup.group.expandedColumn == true) {
+      return _ExpandedColumn(
+        stateManager: stateManager,
+        column: columnGroup.columns.first,
+        height: ((depth + 1) * stateManager.columnHeight),
+      );
+    } else {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          _ColumnGroupTitle(
             stateManager: stateManager,
-            column: columnGroup.columns.first,
-            height: (depth + 1) * stateManager.columnHeight,
-          )
-        : Column(
-            children: [
-              _ColumnGroupTitle(
-                stateManager: stateManager,
-                columnGroup: columnGroup,
-                depth: depth,
-                childrenDepth: _childrenDepth,
-              ),
-              _ColumnGroup(
-                stateManager: stateManager,
-                columnGroup: columnGroup,
-                depth: _childrenDepth,
-              ),
-            ],
-          );
+            columnGroup: columnGroup,
+            depth: depth,
+            childrenDepth: _childrenDepth,
+          ),
+          _ColumnGroup(
+            stateManager: stateManager,
+            columnGroup: columnGroup,
+            depth: _childrenDepth,
+          ),
+        ],
+      );
+    }
   }
 }
 
@@ -98,14 +101,8 @@ class _ColumnGroupTitle extends StatelessWidget {
         ? (depth - childrenDepth) * stateManager.columnHeight
         : depth * stateManager.columnHeight;
 
-    final double groupTitleWidth = columnGroup.columns.fold<double>(
-      0,
-      (previousValue, element) => previousValue + element.width,
-    );
-
     return Container(
       height: groupTitleHeight,
-      width: groupTitleWidth,
       padding: EdgeInsets.symmetric(horizontal: _padding),
       decoration: BoxDecoration(
         border: Border(
@@ -121,21 +118,17 @@ class _ColumnGroupTitle extends StatelessWidget {
           ),
         ),
       ),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: SizedBox(
-          width: groupTitleWidth,
-          child: Text.rich(
-            TextSpan(
-              text: _title,
-              children: _children,
-            ),
-            style: stateManager.configuration!.columnTextStyle,
-            overflow: TextOverflow.ellipsis,
-            softWrap: false,
-            maxLines: 1,
-            textAlign: columnGroup.group.titleTextAlign.value,
+      child: Center(
+        child: Text.rich(
+          TextSpan(
+            text: _title,
+            children: _children,
           ),
+          style: stateManager.configuration!.columnTextStyle,
+          overflow: TextOverflow.ellipsis,
+          softWrap: false,
+          maxLines: 1,
+          textAlign: columnGroup.group.titleTextAlign.value,
         ),
       ),
     );
@@ -162,26 +155,118 @@ class _ColumnGroup extends StatelessWidget {
       );
 
   Widget _makeFieldWidget(PlutoColumn column) {
-    return PlutoBaseColumn(
-      stateManager: stateManager,
-      column: column,
+    return LayoutId(
+      id: column.field,
+      child: PlutoBaseColumn(
+        stateManager: stateManager,
+        column: column,
+      ),
     );
   }
 
   Widget _makeChildWidget(PlutoColumnGroupPair columnGroupPair) {
-    return PlutoBaseColumnGroup(
-      stateManager: stateManager,
-      columnGroup: columnGroupPair,
-      depth: depth,
+    return LayoutId(
+      id: columnGroupPair.key,
+      child: PlutoBaseColumnGroup(
+        stateManager: stateManager,
+        columnGroup: columnGroupPair,
+        depth: depth,
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      children: columnGroup.group.hasFields
-          ? columnGroup.columns.map(_makeFieldWidget).toList()
-          : _separateLinkedGroup.map(_makeChildWidget).toList(),
+    if (columnGroup.group.hasFields) {
+      return CustomMultiChildLayout(
+        delegate: ColumnsLayouter(stateManager, columnGroup.columns),
+        children: columnGroup.columns.map(_makeFieldWidget).toList(),
+      );
+    }
+    return CustomMultiChildLayout(
+      delegate: ColumnGroupLayouter(stateManager, _separateLinkedGroup, depth),
+      children: _separateLinkedGroup.map(_makeChildWidget).toList(),
     );
+  }
+}
+
+class ColumnGroupLayouter extends MultiChildLayoutDelegate {
+  PlutoGridStateManager stateManager;
+  List<PlutoColumnGroupPair> separateLinkedGroups;
+
+  late double totalHeightOfGroup;
+
+  int depth;
+
+  ColumnGroupLayouter(this.stateManager, this.separateLinkedGroups, this.depth)
+      : super();
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    totalHeightOfGroup = (depth + 1) * stateManager.columnHeight;
+    totalHeightOfGroup += stateManager.columnFilterHeight;
+    var totalWidthOfGroup = separateLinkedGroups.fold<double>(
+        0,
+        (previousValue, element) =>
+            previousValue +
+            element.columns.fold(
+                0, (previousValue, element) => previousValue + element.width));
+    return Size(totalWidthOfGroup, totalHeightOfGroup);
+  }
+
+  @override
+  void performLayout(Size size) {
+    double dx = 0;
+    for (PlutoColumnGroupPair pair in separateLinkedGroups) {
+      final double width = pair.columns.fold<double>(
+          0, (previousValue, element) => previousValue + element.width);
+      var boxConstraints =
+          BoxConstraints.tight(Size(width, totalHeightOfGroup));
+      layoutChild(pair.key, boxConstraints);
+      positionChild(pair.key, Offset(dx, 0));
+      dx += width;
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) {
+    return true;
+  }
+}
+
+class ColumnsLayouter extends MultiChildLayoutDelegate {
+  PlutoGridStateManager stateManager;
+  List<PlutoColumn> columns;
+
+  ColumnsLayouter(this.stateManager, this.columns) : super();
+
+  double total_columns_height = 0;
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    total_columns_height = 0;
+    total_columns_height = stateManager.columnHeight;
+    total_columns_height += stateManager.columnFilterHeight;
+    double width = columns.fold(
+        0, (previousValue, element) => previousValue + element.width);
+    return Size(width, total_columns_height);
+  }
+
+  @override
+  void performLayout(Size size) {
+    double dx = 0;
+    for (PlutoColumn col in columns) {
+      final double width = col.width;
+      var boxConstraints =
+          BoxConstraints.tight(Size(width, total_columns_height));
+      layoutChild(col.field, boxConstraints);
+      positionChild(col.field, Offset(dx, 0));
+      dx += width;
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) {
+    return true;
   }
 }

--- a/lib/src/ui/pluto_base_row.dart
+++ b/lib/src/ui/pluto_base_row.dart
@@ -45,16 +45,19 @@ class PlutoBaseRow extends StatelessWidget {
     );
   }
 
-  PlutoBaseCell _buildCell(PlutoColumn column) {
-    return PlutoBaseCell(
-      stateManager: stateManager,
-      cell: row.cells[column.field]!,
-      width: column.width,
-      height: stateManager.rowHeight,
-      column: column,
-      rowIdx: rowIdx,
-      row: row,
-      key: row.cells[column.field]!.key,
+  Widget _buildCell(PlutoColumn column) {
+    return LayoutId(
+      id: column.field,
+      child: PlutoBaseCell(
+        stateManager: stateManager,
+        cell: row.cells[column.field]!,
+        width: column.width,
+        height: stateManager.rowHeight,
+        column: column,
+        rowIdx: rowIdx,
+        row: row,
+        key: row.cells[column.field]!.key,
+      ),
     );
   }
 
@@ -65,8 +68,9 @@ class PlutoBaseRow extends StatelessWidget {
       row: row,
       columns: columns,
       key: ValueKey('rowContainer_${row.key}'),
-      child: Row(
+      child: CustomMultiChildLayout(
         key: ValueKey('rowContainer_${row.key}_row'),
+        delegate: RowCellsLayouter(stateManager, columns),
         children: columns.map(_buildCell).toList(growable: false),
       ),
     );
@@ -79,6 +83,43 @@ class PlutoBaseRow extends StatelessWidget {
       onMove: _handleOnMove,
       builder: _dragTargetBuilder,
     );
+  }
+}
+
+class RowCellsLayouter extends MultiChildLayoutDelegate {
+  PlutoGridStateManager stateManager;
+  List<PlutoColumn> columns;
+
+  RowCellsLayouter(this.stateManager, this.columns);
+
+  double _getWidth() {
+    return columns.fold(
+        0, (previousValue, element) => previousValue + element.width);
+  }
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    return Size(_getWidth(), stateManager.rowHeight);
+  }
+
+  @override
+  void performLayout(Size size) {
+    double dx = 0;
+    for (var element in stateManager.columns) {
+      if (!hasChild(element.field)) continue;
+      var width = element.width;
+      layoutChild(
+          element.field,
+          BoxConstraints.tightFor(
+              width: width, height: stateManager.rowHeight));
+      positionChild(element.field, Offset(dx, 0));
+      dx += width;
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) {
+    return true;
   }
 }
 

--- a/lib/src/ui/pluto_body_columns.dart
+++ b/lib/src/ui/pluto_body_columns.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pluto_grid/pluto_grid.dart';
@@ -90,28 +91,95 @@ class _PlutoBodyColumnsState extends _PlutoBodyColumnsStateWithChange {
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: ListView.builder(
-        controller: _scroll,
-        scrollDirection: Axis.horizontal,
-        physics: const ClampingScrollPhysics(),
-        itemCount: _itemCount,
-        itemBuilder: (ctx, i) {
-          return _showColumnGroups == true
-              ? PlutoBaseColumnGroup(
-                  stateManager: widget.stateManager,
-                  columnGroup: _columnGroups![i],
-                  depth: widget.stateManager.columnGroupDepth(
-                    widget.stateManager.refColumnGroups!,
-                  ),
-                )
-              : PlutoBaseColumn(
-                  stateManager: widget.stateManager,
-                  column: _columns![i],
-                );
-        },
-      ),
+    return SingleChildScrollView(
+      controller: _scroll,
+      scrollDirection: Axis.horizontal,
+      physics: const ClampingScrollPhysics(),
+      child: CustomMultiChildLayout(
+          delegate: MainColumnLayoutDelegate(widget.stateManager, _columns!),
+          children: _showColumnGroups == true
+              ? _columnGroups!
+                  .map((PlutoColumnGroupPair e) => LayoutId(
+                        id: e.key,
+                        child: PlutoBaseColumnGroup(
+                          stateManager: widget.stateManager,
+                          columnGroup: e,
+                          depth: widget.stateManager.columnGroupDepth(
+                            widget.stateManager.refColumnGroups!,
+                          ),
+                        ),
+                      ))
+                  .toList()
+              : _columns!
+                  .map((e) => LayoutId(
+                        id: e.field,
+                        child: PlutoBaseColumn(
+                          stateManager: widget.stateManager,
+                          column: e,
+                        ),
+                      ))
+                  .toList()),
     );
+  }
+}
+
+class MainColumnLayoutDelegate extends MultiChildLayoutDelegate {
+  PlutoGridStateManager stateManager;
+
+  List<PlutoColumn> columns;
+
+  MainColumnLayoutDelegate(this.stateManager, this.columns)
+      : super(relayout: stateManager.resizingChangeNotifier);
+
+  double total_columns_height = 0;
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    total_columns_height = 0;
+    if (stateManager.showColumnGroups) {
+      total_columns_height =
+          stateManager.columnGroupHeight + stateManager.columnHeight;
+    } else {
+      total_columns_height = stateManager.columnHeight;
+    }
+    total_columns_height += stateManager.columnFilterHeight;
+    return Size(
+        columns.fold(
+            0, (previousValue, element) => previousValue += element.width),
+        total_columns_height);
+  }
+
+  @override
+  void performLayout(Size size) {
+    if (stateManager.showColumnGroups) {
+      var separateLinkedGroup = stateManager.separateLinkedGroup(
+          columnGroupList: stateManager.columnGroups, columns: columns);
+      double dx = 0;
+      for (PlutoColumnGroupPair pair in separateLinkedGroup) {
+        if (!hasChild(pair.key)) continue;
+        final double width = pair.columns.fold<double>(
+            0, (previousValue, element) => previousValue + element.width);
+        var boxConstraints =
+            BoxConstraints.tight(Size(width, total_columns_height));
+        layoutChild(pair.key, boxConstraints);
+        positionChild(pair.key, Offset(dx, 0));
+        dx += width;
+      }
+    } else {
+      double dx = 0;
+      for (PlutoColumn col in columns) {
+        var width = col.width;
+        var boxConstraints =
+            BoxConstraints.tight(Size(width, total_columns_height));
+        layoutChild(col.field, boxConstraints);
+        positionChild(col.field, Offset(dx, 0));
+        dx += width;
+      }
+    }
+  }
+
+  @override
+  bool shouldRelayout(covariant MultiChildLayoutDelegate oldDelegate) {
+    return true;
   }
 }

--- a/lib/src/ui/pluto_body_rows.dart
+++ b/lib/src/ui/pluto_body_rows.dart
@@ -108,8 +108,8 @@ class _PlutoBodyRowsState extends _PlutoBodyRowsStateWithChange {
         controller: _horizontalScroll,
         scrollDirection: Axis.horizontal,
         physics: const ClampingScrollPhysics(),
-        child: SizedBox(
-          width: _width,
+        child: CustomSingleChildLayout(
+          delegate: ListResizeDelegate(widget.stateManager, _getColumns()),
           child: ListView.builder(
             controller: _verticalScroll,
             scrollDirection: Axis.vertical,
@@ -129,5 +129,39 @@ class _PlutoBodyRowsState extends _PlutoBodyRowsStateWithChange {
         ),
       ),
     );
+  }
+}
+
+class ListResizeDelegate extends SingleChildLayoutDelegate {
+  PlutoGridStateManager stateManager;
+
+  List<PlutoColumn> columns;
+
+  ListResizeDelegate(this.stateManager, this.columns)
+      : super(relayout: stateManager.resizingChangeNotifier);
+
+  @override
+  bool shouldRelayout(covariant SingleChildLayoutDelegate oldDelegate) {
+    return true;
+  }
+
+  double _getWidth() {
+    return columns.fold(
+        0, (previousValue, element) => previousValue + element.width);
+  }
+
+  @override
+  Size getSize(BoxConstraints constraints) {
+    return constraints.tighten(width: _getWidth()).biggest;
+  }
+
+  @override
+  Offset getPositionForChild(Size size, Size childSize) {
+    return Offset(0, 0);
+  }
+
+  @override
+  BoxConstraints getConstraintsForChild(BoxConstraints constraints) {
+    return constraints.tighten(width: _getWidth());
   }
 }

--- a/lib/src/ui/pluto_left_frozen_columns.dart
+++ b/lib/src/ui/pluto_left_frozen_columns.dart
@@ -66,27 +66,29 @@ class _PlutoLeftFrozenColumnsState
     extends _PlutoLeftFrozenColumnsStateWithChange {
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        physics: const NeverScrollableScrollPhysics(),
-        itemCount: _itemCount,
-        itemBuilder: (ctx, i) {
-          return _showColumnGroups == true
-              ? PlutoBaseColumnGroup(
-                  stateManager: widget.stateManager,
-                  columnGroup: _columnGroups![i],
-                  depth: widget.stateManager.columnGroupDepth(
-                    widget.stateManager.refColumnGroups!,
-                  ),
-                )
-              : PlutoBaseColumn(
-                  stateManager: widget.stateManager,
-                  column: _columns![i],
-                );
-        },
-      ),
-    );
+    return CustomMultiChildLayout(
+        delegate: MainColumnLayoutDelegate(widget.stateManager, _columns!),
+        children: _showColumnGroups == true
+            ? _columnGroups!
+                .map((PlutoColumnGroupPair e) => LayoutId(
+                      id: e.key,
+                      child: PlutoBaseColumnGroup(
+                        stateManager: widget.stateManager,
+                        columnGroup: e,
+                        depth: widget.stateManager.columnGroupDepth(
+                          widget.stateManager.refColumnGroups!,
+                        ),
+                      ),
+                    ))
+                .toList()
+            : _columns!
+                .map((e) => LayoutId(
+                      id: e.field,
+                      child: PlutoBaseColumn(
+                        stateManager: widget.stateManager,
+                        column: e,
+                      ),
+                    ))
+                .toList());
   }
 }

--- a/lib/src/ui/pluto_right_frozen_columns.dart
+++ b/lib/src/ui/pluto_right_frozen_columns.dart
@@ -67,27 +67,29 @@ class _PlutoRightFrozenColumnsState
     extends _PlutoRightFrozenColumnsStateWithChange {
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: _width,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        physics: const NeverScrollableScrollPhysics(),
-        itemCount: _itemCount,
-        itemBuilder: (ctx, i) {
-          return _showColumnGroups == true
-              ? PlutoBaseColumnGroup(
-                  stateManager: widget.stateManager,
-                  columnGroup: _columnGroups![i],
-                  depth: widget.stateManager.columnGroupDepth(
-                    widget.stateManager.refColumnGroups!,
-                  ),
-                )
-              : PlutoBaseColumn(
-                  stateManager: widget.stateManager,
-                  column: _columns![i],
-                );
-        },
-      ),
-    );
+    return CustomMultiChildLayout(
+        delegate: MainColumnLayoutDelegate(widget.stateManager, _columns!),
+        children: _showColumnGroups == true
+            ? _columnGroups!
+                .map((PlutoColumnGroupPair e) => LayoutId(
+                      id: e.key,
+                      child: PlutoBaseColumnGroup(
+                        stateManager: widget.stateManager,
+                        columnGroup: e,
+                        depth: widget.stateManager.columnGroupDepth(
+                          widget.stateManager.refColumnGroups!,
+                        ),
+                      ),
+                    ))
+                .toList()
+            : _columns!
+                .map((e) => LayoutId(
+                      id: e.field,
+                      child: PlutoBaseColumn(
+                        stateManager: widget.stateManager,
+                        column: e,
+                      ),
+                    ))
+                .toList());
   }
 }


### PR DESCRIPTION
A little big of a pull request. 

The main goal was to get rid of the very-large LayoutBuilder in the root of the grid.
Flutter has a very convenient widget for that, it is called CustomMultiChildLayout. it relayouts its children without rebuilding them.

It was rebuilding the whole cells whenever resizing the window or resizing a column. (which was unusable on web and too laggy even on desktop releases)

I've used it on the columns, rows, and the main layout of the grid. 

it is a big change, I know, but resizing anything in the grid now has a fantastic performance (layouting now only takes 4-5 ms).