### PR TITLE
CSV Export - Exports current state of the grid

### DIFF
--- a/demo/lib/main.dart
+++ b/demo/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:demo/screen/feature/export_screen.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -68,6 +69,7 @@ class MyApp extends StatelessWidget {
             const DateTypeColumnScreen(),
         DualModeScreen.routeName: (context) => const DualModeScreen(),
         EditingStateScreen.routeName: (context) => const EditingStateScreen(),
+        ExportScreen.routeName: (context) => const ExportScreen(),
         GridAsPopupScreen.routeName: (context) => const GridAsPopupScreen(),
         ListingModeScreen.routeName: (context) => const ListingModeScreen(),
         MovingScreen.routeName: (context) => const MovingScreen(),

--- a/demo/lib/screen/development_screen.dart
+++ b/demo/lib/screen/development_screen.dart
@@ -1,3 +1,4 @@
+import 'package:file_saver/file_saver.dart';
 import 'package:flutter/material.dart';
 import 'package:pluto_grid/pluto_grid.dart';
 
@@ -375,6 +376,12 @@ class _HeaderState extends State<_Header> {
         .setShowColumnFilter(!widget.stateManager.showColumnFilter);
   }
 
+  void handleExport() async {
+    String title = "pluto_grid_export";
+    var exported = PlutoExport.exportCSV(widget.stateManager);
+    await FileSaver.instance.saveFile("$title.csv", exported, ".csv");
+  }
+
   void setGridSelectingMode(PlutoGridSelectingMode? mode) {
     if (gridSelectingMode == mode || mode == null) {
       return;
@@ -430,6 +437,8 @@ class _HeaderState extends State<_Header> {
               child: const Text('Remove Selected Rows'),
               onPressed: handleRemoveSelectedRowsButton,
             ),
+            ElevatedButton(
+                onPressed: handleExport, child: const Text("Export to CSV")),
             DropdownButtonHideUnderline(
               child: DropdownButton(
                 value: gridSelectingMode,

--- a/demo/lib/screen/feature/export_screen.dart
+++ b/demo/lib/screen/feature/export_screen.dart
@@ -1,0 +1,192 @@
+import 'package:file_saver/file_saver.dart';
+import 'package:flutter/material.dart';
+import 'package:pluto_grid/pluto_grid.dart';
+
+import '../../dummy_data/development.dart';
+import '../../widget/pluto_example_button.dart';
+import '../../widget/pluto_example_screen.dart';
+
+class ExportScreen extends StatefulWidget {
+  static const routeName = 'feature/export';
+
+  const ExportScreen({Key? key}) : super(key: key);
+
+  @override
+  _ExportScreenState createState() => _ExportScreenState();
+}
+
+class _ExportScreenState extends State<ExportScreen> {
+  final List<PlutoColumn> columns = [];
+
+  final List<PlutoRow> rows = [];
+
+  late PlutoGridStateManager stateManager;
+
+  @override
+  void initState() {
+    super.initState();
+
+    columns.addAll([
+      PlutoColumn(
+        title: 'Column 1',
+        field: 'column1',
+        type: PlutoColumnType.text(),
+        enableRowDrag: true,
+        enableRowChecked: true,
+        width: 250,
+        minWidth: 175,
+        renderer: (rendererContext) {
+          return Row(
+            children: [
+              IconButton(
+                icon: const Icon(
+                  Icons.add_circle,
+                ),
+                onPressed: () {
+                  rendererContext.stateManager.insertRows(
+                    rendererContext.rowIdx,
+                    [rendererContext.stateManager.getNewRow()],
+                  );
+                },
+                iconSize: 18,
+                color: Colors.green,
+                padding: const EdgeInsets.all(0),
+              ),
+              IconButton(
+                icon: const Icon(
+                  Icons.remove_circle_outlined,
+                ),
+                onPressed: () {
+                  rendererContext.stateManager
+                      .removeRows([rendererContext.row]);
+                },
+                iconSize: 18,
+                color: Colors.red,
+                padding: const EdgeInsets.all(0),
+              ),
+              Expanded(
+                child: Text(
+                  rendererContext.row.cells[rendererContext.column.field]!.value
+                      .toString(),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+      PlutoColumn(
+        title: 'Column 2',
+        field: 'column2',
+        type: PlutoColumnType.select(<String>['red', 'blue', 'green']),
+        renderer: (rendererContext) {
+          Color textColor = Colors.black;
+
+          if (rendererContext.cell.value == 'red') {
+            textColor = Colors.red;
+          } else if (rendererContext.cell.value == 'blue') {
+            textColor = Colors.blue;
+          } else if (rendererContext.cell.value == 'green') {
+            textColor = Colors.green;
+          }
+
+          return Text(
+            rendererContext.cell.value.toString(),
+            style: TextStyle(
+              color: textColor,
+              fontWeight: FontWeight.bold,
+            ),
+          );
+        },
+      ),
+      PlutoColumn(
+        title: 'Column 3',
+        field: 'column3',
+        type: PlutoColumnType.text(),
+      ),
+      PlutoColumn(
+        title: 'Column 4',
+        field: 'column4',
+        type: PlutoColumnType.text(),
+      ),
+      PlutoColumn(
+        title: 'Column 5',
+        field: 'column5',
+        type: PlutoColumnType.text(),
+        enableEditingMode: false,
+        renderer: (rendererContext) {
+          return Image.asset('assets/images/cat.jpg');
+        },
+      ),
+    ]);
+
+    rows.addAll(DummyData.rowsByColumns(length: 15, columns: columns));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return PlutoExampleScreen(
+      title: 'Export / download as CSV',
+      topTitle: 'Export / download as CSV',
+      topContents: const [
+        Text('You can export grid contents as CSV or TSV'),
+      ],
+      topButtons: [
+        ElevatedButton(
+            onPressed: _defaultExportGridAsCSV,
+            child: const Text("Export to CSV")),
+        ElevatedButton(
+            onPressed: _defaultExportGridAsCSVWithSemicolon,
+            child: const Text("Export to CSV with Semicolon ';'")),
+        ElevatedButton(
+            onPressed: _exportGridAsTSV,
+            child: const Text("Export to TSV (tab separated)")),
+        ElevatedButton(
+            onPressed: _defaultExportGridAsCSVFakeExcel,
+            child: const Text("Export to fake-Excel")),
+        PlutoExampleButton(
+          url:
+              'https://github.com/bosskmk/pluto_grid/blob/master/demo/lib/screen/feature/export_screen.dart',
+        ),
+      ],
+      body: PlutoGrid(
+        columns: columns,
+        rows: rows,
+        onChanged: (PlutoGridOnChangedEvent event) {
+          print(event);
+        },
+        onLoaded: (PlutoGridOnLoadedEvent event) {
+          event.stateManager.setSelectingMode(PlutoGridSelectingMode.cell);
+
+          stateManager = event.stateManager;
+        },
+        // configuration: PlutoConfiguration.dark(),
+      ),
+    );
+  }
+
+  void _defaultExportGridAsCSV() async {
+    String title = "pluto_grid_export";
+    var exported = PlutoExport.exportCSV(stateManager);
+    await FileSaver.instance.saveFile("$title.csv", exported, ".csv");
+  }
+
+  void _defaultExportGridAsCSVFakeExcel() async {
+    String title = "pluto_grid_export";
+    var exported = PlutoExport.exportCSV(stateManager);
+    await FileSaver.instance.saveFile("$title.xls", exported, ".xls");
+  }
+
+  void _exportGridAsTSV() async {
+    String title = "pluto_grid_export";
+    var exported = PlutoExport.exportCSV(stateManager, fieldDelimiter: "\t");
+    await FileSaver.instance.saveFile("$title.csv", exported, ".csv");
+  }
+
+  void _defaultExportGridAsCSVWithSemicolon() async {
+    String title = "pluto_grid_export";
+    var exported = PlutoExport.exportCSV(stateManager, fieldDelimiter: ";");
+    await FileSaver.instance.saveFile("$title.csv", exported, ".csv");
+  }
+}

--- a/demo/lib/screen/home_screen.dart
+++ b/demo/lib/screen/home_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:demo/screen/feature/export_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 
@@ -401,6 +402,14 @@ class PlutoFeatures extends StatelessWidget {
             description: 'Listing mode to open or navigate to the Detail page.',
             onTapLiveDemo: () {
               Navigator.pushNamed(context, ListingModeScreen.routeName);
+            },
+          ),
+          PlutoListTile(
+            title: 'Export',
+            description: 'Exporting grid data as CSV.',
+            trailing: newIcon,
+            onTapLiveDemo: () {
+              Navigator.pushNamed(context, ExportScreen.routeName);
             },
           ),
           PlutoListTile.dark(

--- a/demo/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/demo/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,12 @@
 import FlutterMacOS
 import Foundation
 
+import file_saver
+import path_provider_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/demo/pubspec.lock
+++ b/demo/pubspec.lock
@@ -49,14 +49,21 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
+  csv:
+    dependency: transitive
+    description:
+      name: csv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   fake_async:
     dependency: transitive
     description:
@@ -70,7 +77,28 @@ packages:
       name: faker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0-rc.2"
+    version: "2.0.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
+  file_saver:
+    dependency: "direct main"
+    description:
+      name: file_saver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -99,7 +127,7 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "9.0.0"
+    version: "9.2.0"
   intl:
     dependency: transitive
     description:
@@ -156,13 +184,69 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider:
+    dependency: transitive
+    description:
+      name: path_provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.13"
+  path_provider_ios:
+    dependency: transitive
+    description:
+      name: path_provider_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.2"
   pluto_grid:
     dependency: "direct main"
     description:
@@ -170,6 +254,13 @@ packages:
       relative: true
     source: path
     version: "2.9.3"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.4"
   rainbow_color:
     dependency: "direct main"
     description:
@@ -251,42 +342,56 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "6.1.0"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.16"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.15"
   url_launcher_linux:
     dependency: transitive
     description:
       name: url_launcher_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   url_launcher_macos:
     dependency: transitive
     description:
       name: url_launcher_macos
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   url_launcher_platform_interface:
     dependency: transitive
     description:
       name: url_launcher_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.2"
+    version: "2.0.5"
   url_launcher_web:
     dependency: transitive
     description:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.9"
   url_launcher_windows:
     dependency: transitive
     description:
       name: url_launcher_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "3.0.0"
   vector_math:
     dependency: transitive
     description:
@@ -294,6 +399,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.5.2"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0+1"
 sdks:
-  dart: ">=2.14.0 <3.0.0"
-  flutter: ">=2.5.0"
+  dart: ">=2.15.0 <3.0.0"
+  flutter: ">=2.10.0"

--- a/demo/pubspec.yaml
+++ b/demo/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   url_launcher: ^6.0.3
   font_awesome_flutter: ^9.0.0
   rainbow_color: ^2.0.1
+  file_saver: ^0.1.0
 
 
   # The following adds the Cupertino Icons font to your application.

--- a/demo/windows/flutter/generated_plugin_registrant.cc
+++ b/demo/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <url_launcher_windows/url_launcher_plugin.h>
+#include <file_saver/file_saver_plugin.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  UrlLauncherPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("UrlLauncherPlugin"));
+  FileSaverPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSaverPlugin"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/demo/windows/flutter/generated_plugins.cmake
+++ b/demo/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_saver
   url_launcher_windows
 )
 

--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  csv:
+    dependency: transitive
+    description:
+      name: csv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   cupertino_icons:
     dependency: "direct main"
     description:

--- a/lib/pluto_grid.dart
+++ b/lib/pluto_grid.dart
@@ -28,6 +28,7 @@ export './src/model/pluto_column_group.dart';
 export './src/model/pluto_column_type.dart';
 export './src/model/pluto_row.dart';
 export './src/plugin/pluto_pagination.dart';
+export './src/plugin/pluto_export.dart';
 export './src/pluto_dual_grid.dart';
 export './src/pluto_dual_grid_popup.dart';
 export './src/pluto_grid.dart';

--- a/lib/src/plugin/pluto_export.dart
+++ b/lib/src/plugin/pluto_export.dart
@@ -1,0 +1,68 @@
+import 'dart:typed_data';
+
+import 'package:csv/csv.dart';
+import 'package:pluto_grid/pluto_grid.dart';
+
+class PlutoExport {
+
+  static Uint8List exportCSV(
+    PlutoGridStateManager state, {
+    String? fieldDelimiter,
+    String? textDelimiter,
+    String? textEndDelimiter,
+    String? eol,
+  }) {
+    String toCsv = const ListToCsvConverter().convert(
+      _mapStateToRows(state),
+      fieldDelimiter: fieldDelimiter,
+      textDelimiter: textDelimiter,
+      textEndDelimiter: textEndDelimiter,
+      delimitAllFields: true,
+      eol: eol,
+    );
+
+    return Uint8List.fromList(toCsv.codeUnits);
+  }
+
+  static List<List<String?>> _mapStateToRows(PlutoGridStateManager state) {
+    List<List<String?>> outputRows = [];
+    outputRows.add(state.columns
+        // Apend all VISIBLE columns
+        .where((element) => !element.hide)
+        .map((e) => e.title)
+        .toList());
+
+    List<PlutoRow> rowsToExport;
+
+    // Use filteredList if available
+    // https://github.com/bosskmk/pluto_grid/issues/318#issuecomment-987424407
+    if(state.refRows.filteredList.isNotEmpty) {
+      rowsToExport = state.refRows.filteredList;
+    } else {
+      rowsToExport = state.refRows.originalList;
+    }
+
+    for (var plutoRow in rowsToExport) {
+      outputRows.add(_mapRow(state.columns, plutoRow));
+    }
+
+    return outputRows;
+  }
+
+  static List<String?> _mapRow(
+      List<PlutoColumn> plutoColumns, PlutoRow plutoRow) {
+    List<String?> serializedRow = [];
+
+    // Order is important, so we iterate over columns
+    for (PlutoColumn column in plutoColumns) {
+      // Only VISIBLE columns
+      if(!column.hide) {
+        dynamic value = plutoRow.cells[column.field]?.value;
+        serializedRow
+            .add(value != null ? column.formattedValueForDisplay(value) : null);
+      }
+    }
+
+    return serializedRow;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -155,6 +155,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csv:
+    dependency: "direct main"
+    description:
+      name: csv
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.1"
   dart_style:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   rxdart: ^0.27.3
   linked_scroll_controller: ^0.2.0
   collection: ^1.15.0
+  csv: ^5.0.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
In this PR I've designed an external component that allows you to export the current contents of a PlutoGrid in CSV, TSV, "fake-Excel"...

For the moment I have opted for a minimal solution that must be integrated via a button outside the PlutoGrid UI. Also, for simplicity I have chosen not to include a package like `file_saver` since depending on the platform each developer will want to work with the result of the export to CSV.

I have integrated a new example page as well as a minimal button on the development screen

- [ ] #121
- [ ] #318
- [ ] #376
- [ ] #424