### PR TITLE
Improve padding for table cells and column titles

### DIFF
--- a/lib/src/manager/state/column_state.dart
+++ b/lib/src/manager/state/column_state.dart
@@ -456,12 +456,12 @@ mixin ColumnState implements IPlutoGridState {
 
     // todo : Apply (popup type icon, checkbox, drag indicator, renderer)
 
-    double cellPadding =
+    EdgeInsets cellPadding =
         column.cellPadding ?? configuration!.defaultCellPadding;
 
     resizeColumn(
       column,
-      textPainter.width - column.width + (cellPadding * 2) + 2,
+      textPainter.width - column.width + (cellPadding.left + cellPadding.right) + 2,
     );
   }
 

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -31,7 +31,7 @@ class PlutoColumn {
 
   /// Customisable title padding.
   /// It takes precedence over defaultColumnTitlePadding in PlutoGridConfiguration.
-  double? titlePadding;
+  EdgeInsets? titlePadding;
 
   /// Customize the column with TextSpan or WidgetSpan instead of the column's title string.
   ///

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -52,7 +52,7 @@ class PlutoColumn {
 
   /// Customisable cell padding.
   /// It takes precedence over defaultCellPadding in PlutoGridConfiguration.
-  double? cellPadding;
+  EdgeInsets? cellPadding;
 
   /// Text alignment in Cell. (Left, Right, Center)
   PlutoColumnTextAlign textAlign;

--- a/lib/src/model/pluto_column_group.dart
+++ b/lib/src/model/pluto_column_group.dart
@@ -8,7 +8,7 @@ class PlutoColumnGroup {
 
   final List<PlutoColumnGroup>? children;
 
-  final double? titlePadding;
+  final EdgeInsets? titlePadding;
 
   /// Text alignment in Cell. (Left, Right, Center)
   final PlutoColumnTextAlign titleTextAlign;

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1081,7 +1081,8 @@ class PlutoGridSettings {
   static const EdgeInsets cellPadding = EdgeInsets.symmetric(horizontal: 10);
 
   /// Column title - padding
-  static const double columnTitlePadding = 10;
+  static const EdgeInsets columnTitlePadding =
+      EdgeInsets.symmetric(horizontal: 10);
 
   /// Cell - fontSize
   static const double cellFontSize = 14;

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1078,7 +1078,7 @@ class PlutoGridSettings {
   static const double rowTotalHeight = rowHeight + rowBorderWidth;
 
   /// Cell - padding
-  static const double cellPadding = 10;
+  static const EdgeInsets cellPadding = EdgeInsets.symmetric(horizontal: 10);
 
   /// Column title - padding
   static const double columnTitlePadding = 10;

--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -84,8 +84,8 @@ class PlutoGridConfiguration {
 
   /// Customise cell padding
   /// If there is no cellPadding of PlutoColumn,
-  /// it is the padding value of cell. (Horizontal only)
-  final double defaultCellPadding;
+  /// it is the padding value of cell.
+  final EdgeInsets defaultCellPadding;
 
   /// When you select a value in the pop-up grid, it moves down.
   final bool enableMoveDownAfterSelecting;
@@ -254,7 +254,7 @@ class PlutoGridConfiguration {
     double? columnHeight,
     double? columnFilterHeight,
     double? defaultColumnTitlePadding,
-    double? defaultCellPadding,
+    EdgeInsets? defaultCellPadding,
     bool? enableMoveDownAfterSelecting,
     bool? enableMoveHorizontalInEditing,
     bool? enableRowColorAnimation,

--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -79,8 +79,8 @@ class PlutoGridConfiguration {
 
   /// Customise column title padding
   /// If there is no titlePadding of PlutoColumn,
-  /// it is the title padding of the default column. (Horizontal only)
-  final double defaultColumnTitlePadding;
+  /// it is the title padding of the default column.
+  final EdgeInsets defaultColumnTitlePadding;
 
   /// Customise cell padding
   /// If there is no cellPadding of PlutoColumn,
@@ -253,7 +253,7 @@ class PlutoGridConfiguration {
     double? rowHeight,
     double? columnHeight,
     double? columnFilterHeight,
-    double? defaultColumnTitlePadding,
+    EdgeInsets? defaultColumnTitlePadding,
     EdgeInsets? defaultCellPadding,
     bool? enableMoveDownAfterSelecting,
     bool? enableMoveHorizontalInEditing,

--- a/lib/src/pluto_grid_date_picker.dart
+++ b/lib/src/pluto_grid_date_picker.dart
@@ -46,10 +46,8 @@ class PlutoGridDatePicker {
     double rowsHeight = 6 * itemHeight;
 
     // itemHeight * 2 = Header Height + Column Height
-    double popupHeight = (itemHeight * 2) +
-        rowsHeight +
-        PlutoGridSettings.totalShadowLineWidth +
-        PlutoGridSettings.gridInnerSpacing;
+    double popupHeight =
+        (itemHeight * 2) + rowsHeight + PlutoGridSettings.totalShadowLineWidth + PlutoGridSettings.gridInnerSpacing;
 
     final popupColumns = _buildColumns();
 
@@ -82,7 +80,7 @@ class PlutoGridDatePicker {
       configuration: configuration.copyWith(
         gridBorderRadius: configuration.gridPopupBorderRadius,
         defaultColumnTitlePadding: PlutoGridSettings.columnTitlePadding,
-        defaultCellPadding: 3,
+        defaultCellPadding: const EdgeInsets.symmetric(horizontal: 3),
         rowHeight: configuration.rowHeight,
         enableRowColorAnimation: false,
         enableColumnBorder: false,
@@ -432,9 +430,7 @@ class _DateCellHeaderState extends _DateCellHeaderStateWithChange {
   Widget build(BuildContext context) {
     return Container(
       height: widget.stateManager.rowTotalHeight,
-      padding: const EdgeInsets.symmetric(
-        horizontal: PlutoGridSettings.cellPadding,
-      ),
+      padding: PlutoGridSettings.cellPadding,
       alignment: Alignment.center,
       child: Row(
         children: [

--- a/lib/src/ui/cells/pluto_time_cell.dart
+++ b/lib/src/ui/cells/pluto_time_cell.dart
@@ -65,7 +65,7 @@ class PlutoTimeCellState extends State<PlutoTimeCell>
           widget.stateManager.configuration?.gridPopupBorderRadius ??
               BorderRadius.zero,
       defaultColumnTitlePadding: PlutoGridSettings.columnTitlePadding,
-      defaultCellPadding: 3,
+      defaultCellPadding: const EdgeInsets.symmetric(horizontal: 3),
       rowHeight: widget.stateManager.configuration!.rowHeight,
       enableRowColorAnimation: false,
       enableColumnBorder: false,

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -210,7 +210,7 @@ class PlutoColumnFilterState extends _PlutoColumnFilterStateWithChange {
       ? widget.stateManager.configuration!.cellColorInEditState
       : widget.stateManager.configuration!.cellColorInReadOnlyState;
 
-  double get _padding =>
+  EdgeInsets get _padding =>
       widget.column.titlePadding ??
       widget.stateManager.configuration!.defaultColumnTitlePadding;
 
@@ -240,7 +240,7 @@ class PlutoColumnFilterState extends _PlutoColumnFilterStateWithChange {
 
     return Container(
       height: widget.stateManager.columnFilterHeight,
-      padding: EdgeInsets.symmetric(horizontal: _padding),
+      padding: _padding,
       decoration: BoxDecoration(
         border: Border(
           top: BorderSide(

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -312,7 +312,7 @@ class _BuildColumnWidget extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
-  double get padding =>
+  EdgeInsets get padding =>
       column.titlePadding ??
       stateManager.configuration!.defaultColumnTitlePadding;
 
@@ -324,7 +324,7 @@ class _BuildColumnWidget extends StatelessWidget {
     return Container(
       width: column.width,
       height: height,
-      padding: EdgeInsets.symmetric(horizontal: padding),
+      padding: padding,
       decoration: BoxDecoration(
         color: column.backgroundColor,
         border: Border(

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -102,8 +102,7 @@ class PlutoBaseCell extends StatelessWidget {
         rowIdx: rowIdx,
         row: row,
         column: column,
-        cellPadding: column.cellPadding ??
-            stateManager.configuration!.defaultCellPadding,
+        cellPadding: column.cellPadding ?? stateManager.configuration!.defaultCellPadding,
         child: _BuildCell(
           stateManager: stateManager,
           rowIdx: rowIdx,
@@ -121,7 +120,7 @@ class _CellContainer extends StatelessWidget {
   final PlutoRow row;
   final int rowIdx;
   final PlutoColumn column;
-  final double cellPadding;
+  final EdgeInsets cellPadding;
   final Widget child;
 
   const _CellContainer({
@@ -242,9 +241,7 @@ class _CellContainer extends StatelessWidget {
         builder: (_, decoration, child) {
           return Container(
             decoration: decoration,
-            padding: EdgeInsets.symmetric(
-              horizontal: cellPadding,
-            ),
+            padding: cellPadding,
             clipBehavior: Clip.hardEdge,
             alignment: Alignment.centerLeft,
             child: child,

--- a/lib/src/ui/pluto_base_column_group.dart
+++ b/lib/src/ui/pluto_base_column_group.dart
@@ -84,7 +84,7 @@ class _ColumnGroupTitle extends StatelessWidget {
     required this.childrenDepth,
   });
 
-  double get _padding =>
+  EdgeInsets get _padding =>
       columnGroup.group.titlePadding ??
       stateManager.configuration!.defaultColumnTitlePadding;
 
@@ -103,7 +103,7 @@ class _ColumnGroupTitle extends StatelessWidget {
 
     return Container(
       height: groupTitleHeight,
-      padding: EdgeInsets.symmetric(horizontal: _padding),
+      padding: _padding,
       decoration: BoxDecoration(
         color: columnGroup.group.backgroundColor,
         border: Border(


### PR DESCRIPTION
I have changed padding from double to EdgeInsets, so now it passed value directly instead passing double with EdgeInsets.symmetric(horizontal: double_value)
Signed-off-by: Dmitry Sboychakov <sboichakov@gmail.com>