### PR TITLE
Introduce new _disabledBorder property.

### DIFF
--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -58,6 +58,13 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
             width: 0.0),
         borderRadius: BorderRadius.zero,
       );
+  
+  InputBorder get _disabledBorder => OutlineInputBorder(
+        borderSide: BorderSide(
+            color: stateManager.configuration!.style.inactivatedBorderColor,
+            width: 0.0),
+        borderRadius: BorderRadius.zero,
+      );
 
   Color get _textFieldColor => _enabled
       ? stateManager.configuration!.style.cellColorInEditState
@@ -254,6 +261,7 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
             fillColor: _textFieldColor,
             border: _border,
             enabledBorder: _border,
+            disabledBorder: _disabledBorder,
             focusedBorder: _enabledBorder,
             contentPadding: const EdgeInsets.all(5),
           ),


### PR DESCRIPTION
The new _disabledBorder property is using the inactiveBorderColor from the style configuration object. This way the border of the filter field can also be customisable even in the disabled state.