### PR TITLE
Currency column type

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -134,6 +134,7 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
           columnGroups: columnGroups,
           onLoaded: (PlutoGridOnLoadedEvent event) {
             stateManager = event.stateManager;
+            stateManager.setShowColumnFilter(true);
           },
           onChanged: (PlutoGridOnChangedEvent event) {
             print(event);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,24 +70,25 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
       title: 'salary',
       field: 'salary',
       type: PlutoColumnType.currency(),
-      // footerRenderer: (rendererContext) {
-      //   return PlutoAggregateColumnFooter(
-      //     rendererContext: rendererContext,
-      //     type: PlutoAggregateColumnType.sum,
-      //     format: '#,###',
-      //     alignment: Alignment.center,
-      //     titleSpanBuilder: (text) {
-      //       return [
-      //         const TextSpan(
-      //           text: 'Sum',
-      //           style: TextStyle(color: Colors.red),
-      //         ),
-      //         const TextSpan(text: ' : '),
-      //         TextSpan(text: text),
-      //       ];
-      //     },
-      //   );
-      // },
+      footerRenderer: (rendererContext) {
+        return PlutoAggregateColumnFooter(
+          rendererContext: rendererContext,
+          formatAsCurrency: true,
+          type: PlutoAggregateColumnType.sum,
+          format: '#,###',
+          alignment: Alignment.center,
+          titleSpanBuilder: (text) {
+            return [
+              const TextSpan(
+                text: 'Sum',
+                style: TextStyle(color: Colors.red),
+              ),
+              const TextSpan(text: ' : '),
+              TextSpan(text: text),
+            ];
+          },
+        );
+      },
     ),
   ];
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -70,6 +70,24 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
       title: 'salary',
       field: 'salary',
       type: PlutoColumnType.currency(),
+      // footerRenderer: (rendererContext) {
+      //   return PlutoAggregateColumnFooter(
+      //     rendererContext: rendererContext,
+      //     type: PlutoAggregateColumnType.sum,
+      //     format: '#,###',
+      //     alignment: Alignment.center,
+      //     titleSpanBuilder: (text) {
+      //       return [
+      //         const TextSpan(
+      //           text: 'Sum',
+      //           style: TextStyle(color: Colors.red),
+      //         ),
+      //         const TextSpan(text: ' : '),
+      //         TextSpan(text: text),
+      //       ];
+      //     },
+      //   );
+      // },
     ),
   ];
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -66,6 +66,11 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
       field: 'working_time',
       type: PlutoColumnType.time(),
     ),
+    PlutoColumn(
+      title: 'salary',
+      field: 'salary',
+      type: PlutoColumnType.currency(),
+    ),
   ];
 
   final List<PlutoRow> rows = [
@@ -77,6 +82,7 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
         'role': PlutoCell(value: 'Programmer'),
         'joined': PlutoCell(value: '2021-01-01'),
         'working_time': PlutoCell(value: '09:00'),
+        'salary': PlutoCell(value: 300),
       },
     ),
     PlutoRow(
@@ -87,6 +93,7 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
         'role': PlutoCell(value: 'Designer'),
         'joined': PlutoCell(value: '2021-02-01'),
         'working_time': PlutoCell(value: '10:00'),
+        'salary': PlutoCell(value: 400),
       },
     ),
     PlutoRow(
@@ -97,6 +104,7 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
         'role': PlutoCell(value: 'Owner'),
         'joined': PlutoCell(value: '2021-03-01'),
         'working_time': PlutoCell(value: '11:00'),
+        'salary': PlutoCell(value: 700),
       },
     ),
   ];

--- a/lib/src/helper/pluto_aggregate_helper.dart
+++ b/lib/src/helper/pluto_aggregate_helper.dart
@@ -10,16 +10,7 @@ class PlutoAggregateHelper {
   }) {
     num sum = 0;
 
-    if (column.type.isNumber || _hasColumnField(rows: rows, column: column)) {
-      sum = rows.fold(0, (p, e) {
-        final cell = e.cells[column.field]!;
-
-        if (filter == null || filter(cell)) {
-          return p += cell.value!;
-        }
-        return p;
-      });
-    } else if (column.type.isCurrency) {
+    if (column.type.isCurrency) {
       final currencyFormat = column.type.currency!.currencyFormat;
 
       sum = rows.fold(0, (p, e) {
@@ -27,6 +18,16 @@ class PlutoAggregateHelper {
 
         if (filter == null || filter(cell)) {
           return p += currencyFormat.parse(cell.value!);
+        }
+        return p;
+      });
+    } else if (column.type.isNumber ||
+        _hasColumnField(rows: rows, column: column)) {
+      sum = rows.fold(0, (p, e) {
+        final cell = e.cells[column.field]!;
+
+        if (filter == null || filter(cell)) {
+          return p += cell.value!;
         }
         return p;
       });
@@ -41,20 +42,7 @@ class PlutoAggregateHelper {
   }) {
     num sum = 0;
     int itemCount = 0;
-
-    if (column.type.isNumber || _hasColumnField(rows: rows, column: column)) {
-      sum = rows.fold(0, (p, e) {
-        final cell = e.cells[column.field]!;
-
-        if (filter == null || filter(cell)) {
-          ++itemCount;
-          return p += cell.value!;
-        }
-        return p;
-      });
-
-      return sum / itemCount;
-    } else if (column.type.isCurrency) {
+    if (column.type.isCurrency) {
       final currencyFormat = column.type.currency!.currencyFormat;
 
       sum = rows.fold(0, (p, e) {
@@ -63,6 +51,19 @@ class PlutoAggregateHelper {
         if (filter == null || filter(cell)) {
           ++itemCount;
           return p += currencyFormat.parse(cell.value!);
+        }
+        return p;
+      });
+
+      return sum / itemCount;
+    } else if (column.type.isNumber ||
+        _hasColumnField(rows: rows, column: column)) {
+      sum = rows.fold(0, (p, e) {
+        final cell = e.cells[column.field]!;
+
+        if (filter == null || filter(cell)) {
+          ++itemCount;
+          return p += cell.value!;
         }
         return p;
       });
@@ -89,7 +90,8 @@ class PlutoAggregateHelper {
     late Iterable<num> mapValues;
     if (column.type.isCurrency) {
       final currencyFormat = column.type.currency!.currencyFormat;
-      mapValues = foundItems.map((e) => currencyFormat.parse(e.cells[column.field]!.value));
+      mapValues = foundItems
+          .map((e) => currencyFormat.parse(e.cells[column.field]!.value));
     } else {
       mapValues = foundItems.map((e) => e.cells[column.field]!.value);
     }
@@ -102,7 +104,8 @@ class PlutoAggregateHelper {
     required PlutoColumn column,
     PlutoAggregateFilter? filter,
   }) {
-    if (!(column.type.isNumber || column.type.isCurrency) || !_hasColumnField(rows: rows, column: column)) {
+    if (!(column.type.isNumber || column.type.isCurrency) ||
+        !_hasColumnField(rows: rows, column: column)) {
       return null;
     }
 
@@ -113,7 +116,8 @@ class PlutoAggregateHelper {
     late Iterable<num> mapValues;
     if (column.type.isCurrency) {
       final currencyFormat = column.type.currency!.currencyFormat;
-      mapValues = foundItems.map((e) => currencyFormat.parse(e.cells[column.field]!.value));
+      mapValues = foundItems
+          .map((e) => currencyFormat.parse(e.cells[column.field]!.value));
     } else {
       mapValues = foundItems.map((e) => e.cells[column.field]!.value);
     }

--- a/lib/src/manager/state/keyboard_state.dart
+++ b/lib/src/manager/state/keyboard_state.dart
@@ -113,6 +113,9 @@ mixin KeyboardState implements IPlutoGridState {
       // Time type column can be moved left or right even in edit state
       else if (currentColumn?.type.isTime == true) {
       }
+      // Currency type column can be moved left or right even in edit state
+      else if (currentColumn?.type.isCurrency == true) {
+      }
       // Read only type column can be moved left or right even in edit state
       else if (currentColumn?.readOnly == true) {
       }

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -296,7 +296,7 @@ class PlutoColumn {
     if (type.isNumber) {
       return type.number!.applyFormat(value);
     } else if (type.isCurrency) {
-      type.money.applyFormat(value);
+      type.currency.applyFormat(value);
     }
 
     return value.toString();
@@ -316,7 +316,7 @@ class PlutoColumn {
           .toString()
           .replaceAll('.', type.number!.numberFormat.symbols.DECIMAL_SEP);
     } else if (type.isCurrency) {
-      return type.money!.currencyFormat.parse(value).toString();
+      return type.currency!.currencyFormat.parse(value).toString();
     }
 
     if (formatter != null) {

--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -295,6 +295,8 @@ class PlutoColumn {
   String formattedValueForType(dynamic value) {
     if (type.isNumber) {
       return type.number!.applyFormat(value);
+    } else if (type.isCurrency) {
+      type.money.applyFormat(value);
     }
 
     return value.toString();
@@ -313,6 +315,8 @@ class PlutoColumn {
       return value
           .toString()
           .replaceAll('.', type.number!.numberFormat.symbols.DECIMAL_SEP);
+    } else if (type.isCurrency) {
+      return type.money!.currencyFormat.parse(value).toString();
     }
 
     if (formatter != null) {

--- a/lib/src/model/pluto_column_type.dart
+++ b/lib/src/model/pluto_column_type.dart
@@ -451,6 +451,7 @@ class PlutoColumnTypeTime implements PlutoColumnType {
     return v;
   }
 }
+
 //TODO implement functions
 class PlutoColumnTypeCurrency
     implements
@@ -471,7 +472,7 @@ class PlutoColumnTypeCurrency
   PlutoColumnTypeCurrency({
     this.defaultValue,
     required this.locale,
-  })  : currencyFormat = intl.NumberFormat.simpleCurrency(locale: locale);
+  }) : currencyFormat = intl.NumberFormat.simpleCurrency(locale: locale);
 
   @override
   late final intl.NumberFormat currencyFormat;
@@ -493,6 +494,13 @@ class PlutoColumnTypeCurrency
 
   @override
   dynamic makeCompareValue(dynamic v) {
+    if (v.runtimeType == String) {
+      try {
+        return currencyFormat.parse(v);
+      } catch (_) {
+        return 0;
+      }
+    }
     return v.runtimeType != num ? num.tryParse(v.toString()) ?? 0 : v;
   }
 

--- a/lib/src/model/pluto_column_type.dart
+++ b/lib/src/model/pluto_column_type.dart
@@ -160,7 +160,7 @@ extension PlutoColumnTypeExtension on PlutoColumnType? {
         : throw TypeError();
   }
 
-  PlutoColumnTypeCurrency? get money {
+  PlutoColumnTypeCurrency? get currency {
     return this is PlutoColumnTypeCurrency
         ? this as PlutoColumnTypeCurrency?
         : throw TypeError();
@@ -452,7 +452,6 @@ class PlutoColumnTypeTime implements PlutoColumnType {
   }
 }
 
-//TODO implement functions
 class PlutoColumnTypeCurrency
     implements
         PlutoColumnType,

--- a/lib/src/plugin/pluto_aggregate_column_footer.dart
+++ b/lib/src/plugin/pluto_aggregate_column_footer.dart
@@ -109,6 +109,8 @@ class PlutoAggregateColumnFooter extends PlutoStatefulWidget {
 
   final EdgeInsets? padding;
 
+  final bool formatAsCurrency;
+
   const PlutoAggregateColumnFooter({
     required this.rendererContext,
     required this.type,
@@ -118,6 +120,7 @@ class PlutoAggregateColumnFooter extends PlutoStatefulWidget {
     this.titleSpanBuilder,
     this.alignment,
     this.padding,
+    this.formatAsCurrency = false,
     super.key,
   });
 
@@ -147,7 +150,9 @@ class PlutoAggregateColumnFooterState
   void initState() {
     super.initState();
 
-    _numberFormat = NumberFormat(widget.format, widget.locale);
+    _numberFormat = widget.formatAsCurrency
+        ? NumberFormat.simpleCurrency(locale: widget.locale) 
+        : NumberFormat(widget.format, widget.locale);
 
     _setAggregator();
 

--- a/lib/src/ui/cells/decimal_imput_formatter.dart
+++ b/lib/src/ui/cells/decimal_imput_formatter.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/services.dart';
+
+// https://stackoverflow.com/questions/54454983/allow-only-two-decimal-number-in-flutter-input
+class DecimalTextInputFormatter extends TextInputFormatter {
+  DecimalTextInputFormatter({
+    int? decimalRange,
+    required bool activatedNegativeValues,
+    required bool allowFirstDot,
+    required String decimalSeparator,
+  }) : assert(decimalRange == null || decimalRange >= 0,
+            'DecimalTextInputFormatter declaration error') {
+    String dp = (decimalRange != null && decimalRange > 0)
+        ? '([$decimalSeparator][0-9]{0,$decimalRange}){0,1}'
+        : '';
+    String num = '[0-9]*$dp';
+
+    if (activatedNegativeValues) {
+      final firstSymbols = allowFirstDot ? '[-$decimalSeparator]' : '[-]';
+
+      _exp = RegExp(
+        '^(((($firstSymbols){0,1})|(($firstSymbols){0,1}[0-9]$num))){0,1}\$',
+      );
+    } else {
+      _exp = RegExp('^($num){0,1}\$');
+    }
+  }
+
+  late RegExp _exp;
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (_exp.hasMatch(newValue.text)) {
+      return newValue;
+    }
+    return oldValue;
+  }
+}

--- a/lib/src/ui/cells/pluto_currency_cell.dart
+++ b/lib/src/ui/cells/pluto_currency_cell.dart
@@ -50,7 +50,7 @@ class PlutoCurrencyCellState extends State<PlutoCurrencyCell>
   void initState() {
     super.initState();
 
-    final numberColumn = widget.column.type.money!;
+    final numberColumn = widget.column.type.currency!;
 
     decimalRange = 2;
 

--- a/lib/src/ui/cells/pluto_currency_cell.dart
+++ b/lib/src/ui/cells/pluto_currency_cell.dart
@@ -5,7 +5,7 @@ import 'package:pluto_grid/pluto_grid.dart';
 import 'decimal_imput_formatter.dart';
 import 'text_cell.dart';
 
-class PlutoNumberCell extends StatefulWidget implements TextCell {
+class PlutoCurrencyCell extends StatefulWidget implements TextCell {
   @override
   final PlutoGridStateManager stateManager;
 
@@ -18,7 +18,7 @@ class PlutoNumberCell extends StatefulWidget implements TextCell {
   @override
   final PlutoRow row;
 
-  const PlutoNumberCell({
+  const PlutoCurrencyCell({
     required this.stateManager,
     required this.cell,
     required this.column,
@@ -27,11 +27,11 @@ class PlutoNumberCell extends StatefulWidget implements TextCell {
   }) : super(key: key);
 
   @override
-  PlutoNumberCellState createState() => PlutoNumberCellState();
+  PlutoCurrencyCellState createState() => PlutoCurrencyCellState();
 }
 
-class PlutoNumberCellState extends State<PlutoNumberCell>
-    with TextCellState<PlutoNumberCell> {
+class PlutoCurrencyCellState extends State<PlutoCurrencyCell>
+    with TextCellState<PlutoCurrencyCell> {
   late final int decimalRange;
 
   late final bool activatedNegative;
@@ -50,15 +50,15 @@ class PlutoNumberCellState extends State<PlutoNumberCell>
   void initState() {
     super.initState();
 
-    final numberColumn = widget.column.type.number!;
+    final numberColumn = widget.column.type.money!;
 
-    decimalRange = numberColumn.decimalPoint;
+    decimalRange = 2;
 
-    activatedNegative = numberColumn.negative;
+    activatedNegative = true;
 
-    allowFirstDot = numberColumn.allowFirstDot;
+    allowFirstDot = true;
 
-    decimalSeparator = numberColumn.numberFormat.symbols.DECIMAL_SEP;
+    decimalSeparator = numberColumn.currencyFormat.symbols.DECIMAL_SEP;
 
     inputFormatters = [
       DecimalTextInputFormatter(
@@ -70,7 +70,7 @@ class PlutoNumberCellState extends State<PlutoNumberCell>
     ];
 
     keyboardType = TextInputType.numberWithOptions(
-      decimal: decimalRange > 0,
+      decimal: true,
       signed: activatedNegative,
     );
   }

--- a/lib/src/ui/pluto_base_cell.dart
+++ b/lib/src/ui/pluto_base_cell.dart
@@ -379,6 +379,13 @@ class _BuildCellState extends PlutoStateWithChange<_BuildCell> {
           column: widget.column,
           row: widget.row,
         );
+      } else if (widget.column.type.isCurrency) {
+        return PlutoCurrencyCell(
+          stateManager: stateManager,
+          cell: widget.cell,
+          column: widget.column,
+          row: widget.row,
+        );
       }
     }
 

--- a/lib/src/ui/ui.dart
+++ b/lib/src/ui/ui.dart
@@ -4,6 +4,7 @@ export 'cells/pluto_number_cell.dart';
 export 'cells/pluto_select_cell.dart';
 export 'cells/pluto_text_cell.dart';
 export 'cells/pluto_time_cell.dart';
+export 'cells/pluto_currency_cell.dart';
 export 'columns/pluto_column_filter.dart';
 export 'columns/pluto_column_title.dart';
 export 'miscellaneous/pluto_state_with_change.dart';

--- a/lib/src/ui/ui.dart
+++ b/lib/src/ui/ui.dart
@@ -5,6 +5,7 @@ export 'cells/pluto_select_cell.dart';
 export 'cells/pluto_text_cell.dart';
 export 'cells/pluto_time_cell.dart';
 export 'cells/pluto_currency_cell.dart';
+export 'cells/decimal_imput_formatter.dart';
 export 'columns/pluto_column_filter.dart';
 export 'columns/pluto_column_title.dart';
 export 'miscellaneous/pluto_state_with_change.dart';

--- a/test/helper/row_helper.dart
+++ b/test/helper/row_helper.dart
@@ -27,7 +27,7 @@ class RowHelper {
               return cellOfTimeColumn(column, rowIdx);
             } else if (column.type.isSelect) {
               return cellOfTimeColumn(column, rowIdx);
-            } else if (column.type.isNumber) {
+            } else if (column.type.isNumber || column.type.isCurrency) {
               return cellOfNumberColumn(column, rowIdx);
             }
 


### PR DESCRIPTION
Today users have to create by themselves a currency column (and implement the necessary filters and functions).

It'll be awesome if pluto had this by default

- [x] factory PlutoColumnType.currency 
- [x] PlutoColumnTypeCurrency
- [x] sort column
- [x] PlutoCurrencyCell
- [x] edit column value
- [x] Filter column
- [x] New 5.1.0 aggregation functions
- [ ] Tests

