### PR TITLE
Fix RTL initiation flicker

### DIFF
--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -786,7 +786,8 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
 
   PlutoGridLayoutDelegate(this._stateManager, this._textDirection)
       : super(relayout: _stateManager.resizingChangeNotifier){
-    // _stateManager.setTextDirection(_textDirection);
+    // set textDirection before the first frame is laid-out
+    _stateManager.setTextDirection(_textDirection);
   }
 
   @override

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -785,7 +785,9 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
   final TextDirection _textDirection;
 
   PlutoGridLayoutDelegate(this._stateManager, this._textDirection)
-      : super(relayout: _stateManager.resizingChangeNotifier);
+      : super(relayout: _stateManager.resizingChangeNotifier){
+    // _stateManager.setTextDirection(_textDirection);
+  }
 
   @override
   void performLayout(Size size) {
@@ -1174,7 +1176,6 @@ class PlutoGridLayoutDelegate extends MultiChildLayoutDelegate {
 
   void _performLayoutOnPostFrame(Size size) {
     bool update = false;
-
     if (_stateManager.showFrozenColumn !=
         _stateManager.shouldShowFrozenColumns(size.width)) {
       update = true;


### PR DESCRIPTION
When using `RTL` layout a flicker happens (double-layout) because the first frame is laid-out using the default `TextDirection` which is always `LTR` and then the actual direction is set inside of `_performLayoutOnPostFrame`  which results to a new layout.

I'm just hard reloading here

![before](https://user-images.githubusercontent.com/55059449/204268273-b6abc039-b3f9-4041-8805-238edee4c10a.gif)

setting the actual `TextDirection` earlier inside of `PlutoGridLayoutDelegate`'s constructor fixes the issue.
