### PR TITLE
Fix column context menu is triggered after drag (column resizing).

### DIFF
--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -95,10 +95,9 @@ class PlutoColumnTitleState extends PlutoStateWithChange<PlutoColumnTitle> {
   }
 
   void _handleOnPointMove(PointerMoveEvent event) {
-    _isPointMoving =
-        (_columnRightPosition - event.position).distanceSquared > 0.5;
+    _isPointMoving = true;
 
-    if (!_isPointMoving) {
+    if ((_columnRightPosition - event.position).distanceSquared <= 0.5) {
       return;
     }
 


### PR DESCRIPTION
Hello @bosskmk 
Column context menu tap should be canceled after the slightest movement. 
![context_menu_before](https://user-images.githubusercontent.com/55059449/204285684-3dacd775-d171-4b21-8016-a6ec74808467.gif)

This PR simply sets `_isPointMoving = true` whenever `onPointMove` is triggered.