### PR TITLE
disable pop up menu when pass in empty array

### DIFF
--- a/demo/lib/screen/feature/column_menu_screen.dart
+++ b/demo/lib/screen/feature/column_menu_screen.dart
@@ -113,3 +113,23 @@ enum _UserColumnMenuItem {
   moveNext,
   movePrevious,
 }
+
+/// [CustomColumnMenu] override buildMenuItems with returnning empty array to make that pop up menu won't trigger
+class CustomColumnMenu implements PlutoColumnMenuDelegate {
+  @override
+  List<PopupMenuEntry> buildMenuItems({
+    required PlutoGridStateManager stateManager,
+    required PlutoColumn column,
+  }) {
+    return [];
+  }
+
+  @override
+  void onSelected({
+    required BuildContext context,
+    required PlutoGridStateManager stateManager,
+    required PlutoColumn column,
+    required bool mounted,
+    required selected,
+  }) {}
+}

--- a/lib/src/helper/show_column_menu.dart
+++ b/lib/src/helper/show_column_menu.dart
@@ -84,18 +84,24 @@ Future<T?>? showColumnMenu<T>({
   final RenderBox overlay =
       Overlay.of(context).context.findRenderObject() as RenderBox;
 
-  return showMenu<T>(
-    context: context,
-    color: backgroundColor,
-    position: RelativeRect.fromLTRB(
-      position.dx,
-      position.dy,
-      position.dx + overlay.size.width,
-      position.dy + overlay.size.height,
-    ),
-    items: items,
-    useRootNavigator: true,
-  );
+  // Add isNotEmpty checking here so that won't pop up menu 
+  // when can pass in empty array on buildMenuItems on class PlutoColumnMenuDelegate
+  // refer to ColumnMenuScreen class
+  if (items.isNotEmpty){
+    return showMenu<T>(
+      context: context,
+      color: backgroundColor,
+      position: RelativeRect.fromLTRB(
+        position.dx,
+        position.dy,
+        position.dx + overlay.size.width,
+        position.dy + overlay.size.height,
+      ),
+      items: items,
+      useRootNavigator: true,
+    );
+  }
+  
 }
 
 List<PopupMenuEntry<PlutoGridColumnMenuItem>> _getDefaultColumnMenuItems({


### PR DESCRIPTION
able to return empty array on buildMenuItems on class which implements PlutoColumnMenuDelegate by putting on field columnMenuDelegate and checking the items if it is empty then wont returning for showMenu

In short, putting empty array then pop up menu won't be shown