### PR TITLE
Fixed issue with null being formatted as 'null'

### DIFF
--- a/packages/pluto_grid_export/lib/src/abstract_text_export.dart
+++ b/packages/pluto_grid_export/lib/src/abstract_text_export.dart
@@ -41,8 +41,7 @@ abstract class AbstractTextExport<T> {
     // Order is important, so we iterate over columns
     for (PlutoColumn column in visibleColumns(state)) {
       dynamic value = plutoRow.cells[column.field]?.value;
-      serializedRow
-          .add(value != null ? column.formattedValueForDisplay(value) : null);
+      serializedRow.add(column.formattedValueForDisplay(value));
     }
 
     return serializedRow;


### PR DESCRIPTION
Removed ternary operator ignoring formatter if the value is null.
Function signature still accepts dynamic which means everything should work as before.
Fixes #833