### PR TITLE
fix: use same intl version as in Flutter 3.10.0 SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.18.1
+  intl: ^0.18.0
   rxdart: ^0.27.7
   collection: ^1.17.1
 


### PR DESCRIPTION
Fixes https://github.com/bosskmk/pluto_grid/issues/836