### PR TITLE
Add and apply `enableGridBorder` config parameter

### DIFF
--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1224,10 +1224,12 @@ class _GridContainer extends StatelessWidget {
           decoration: BoxDecoration(
             color: style.gridBackgroundColor,
             borderRadius: style.gridBorderRadius,
-            border: Border.all(
+            border: style.enableGridBorder
+                ? Border.all(
               color: style.gridBorderColor,
               width: PlutoGridSettings.gridBorderWidth,
-            ),
+                  )
+                : null,
           ),
           child: Padding(
             padding: const EdgeInsets.all(PlutoGridSettings.gridPadding),

--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -211,6 +211,7 @@ class PlutoGridStyleConfig {
     this.iconColor = Colors.black26,
     this.disabledIconColor = Colors.black12,
     this.menuBackgroundColor = Colors.white,
+    this.enableGridBorder = true,
     this.gridBorderColor = const Color(0xFFA1A5AE),
     this.borderColor = const Color(0xFFDDE2EB),
     this.activatedBorderColor = Colors.lightBlue,
@@ -267,6 +268,7 @@ class PlutoGridStyleConfig {
     this.iconColor = Colors.white38,
     this.disabledIconColor = Colors.white12,
     this.menuBackgroundColor = const Color(0xFF414141),
+    this.enableGridBorder = true,
     this.gridBorderColor = const Color(0xFF666666),
     this.borderColor = const Color(0xFF222222),
     this.activatedBorderColor = const Color(0xFFFFFFFF),
@@ -368,6 +370,9 @@ class PlutoGridStyleConfig {
 
   /// BackgroundColor of Popup menu. (column menu)
   final Color menuBackgroundColor;
+
+  /// Enables the border around the [PlutoGrid].
+  final bool enableGridBorder;
 
   /// Set the border color of [PlutoGrid].
   final Color gridBorderColor;


### PR DESCRIPTION
Sometimes the border around `PlutoGrid` is not required so I've added the `enabgleGridBorder` to `PlutoGridStyleConfig` which will allows to customize this feature.