### PR TITLE
onSelectedItem function in plutoColumnType.select

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:flutter/material.dart';
 import 'package:pluto_grid/pluto_grid.dart';
 
@@ -50,11 +52,20 @@ class _PlutoGridExamplePageState extends State<PlutoGridExamplePage> {
     PlutoColumn(
       title: 'Role',
       field: 'role',
-      type: PlutoColumnType.select(<String>[
-        'Programmer',
-        'Designer',
-        'Owner',
-      ]),
+      type: PlutoColumnType.select(
+        <String>[
+          'Programmer',
+          'Designer',
+          'Owner',
+        ],
+        onItemSelected: (PlutoGridOnSelectedEvent event) {
+          if (event.cell!.value == "Programmer") {
+            print("Hello Programmer");
+          } else {
+            print("Hello Developer");
+          }
+        },
+      ),
     ),
     PlutoColumn(
       title: 'Joined',

--- a/lib/src/model/pluto_column_type.dart
+++ b/lib/src/model/pluto_column_type.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart' as intl;
+import 'package:pluto_grid/pluto_grid.dart';
 
 abstract class PlutoColumnType {
   dynamic get defaultValue;
@@ -87,17 +88,26 @@ abstract class PlutoColumnType {
 
   /// Provides a selection list and sets it as a selection column.
   ///
+  ///The function[onItemSelected] is callback function, which is called
+  ///when selecting an item from the items list.
+  ///
+  ///when selecting an item the [onItemSelected] function will be called
+  ///immediately and it return [PlutoGridOnSelectedEvent] event, so you 
+  ///you can use it make decisions.
+  ///
   /// If [enableColumnFilter] is true, column filtering is enabled in the selection popup.
   ///
   /// Set the suffixIcon in the [popupIcon] cell. Tapping this icon will open a selection popup.
   /// The default icon is displayed, and if this value is set to null , the icon does not appear.
   factory PlutoColumnType.select(
     List<dynamic> items, {
+    final Function(PlutoGridOnSelectedEvent event)? onItemSelected,
     dynamic defaultValue = '',
     bool enableColumnFilter = false,
     IconData? popupIcon = Icons.arrow_drop_down,
   }) {
     return PlutoColumnTypeSelect(
+      onItemSelected: onItemSelected ?? (event) {},
       defaultValue: defaultValue,
       items: items,
       enableColumnFilter: enableColumnFilter,
@@ -360,10 +370,13 @@ class PlutoColumnTypeSelect
 
   final bool enableColumnFilter;
 
+  final Function(PlutoGridOnSelectedEvent event) onItemSelected;
+
   @override
   final IconData? popupIcon;
 
   const PlutoColumnTypeSelect({
+    required this.onItemSelected,
     this.defaultValue,
     required this.items,
     required this.enableColumnFilter,

--- a/lib/src/ui/cells/pluto_select_cell.dart
+++ b/lib/src/ui/cells/pluto_select_cell.dart
@@ -85,6 +85,12 @@ class PlutoSelectCellState extends State<PlutoSelectCell>
   }
 
   @override
+  void onSelected(PlutoGridOnSelectedEvent event) {
+    widget.column.type.select.onItemSelected(event);
+    super.onSelected(event);
+  }
+
+  @override
   void onLoaded(PlutoGridOnLoadedEvent event) {
     super.onLoaded(event);
 


### PR DESCRIPTION
Adding onSelectedItem function that can be passed by the developer (later) .
 
The function[onItemSelected] is callback function, which is called when selecting an item from the items list.
in other words when selecting an item the [onItemSelected] function will be called immediately and it return [PlutoGridOnSelectedEvent] event, so you  you can use it make decisions.

for example: 
let's assume that i want to print  a string base on the user's selction, if the user chooses programming I will print "Hello programmer", else I will print "Hello Developer". Bys using the onSelectedItem function we can do this using the following simple code:
``` dart
   PlutoColumn(
      title: 'Role',
      field: 'role',
      type: PlutoColumnType.select(
        <String>[
          'Programmer',
          'Designer',
          'Owner',
        ],
        onItemSelected: (PlutoGridOnSelectedEvent event) {
          if (event.cell!.value == "Programmer") {
            print("Hello Programmer");
          } else {
            print("Hello Developer");
          }
        },
      ),
    ),
```

Actually we can use this function in many ways, for example to change other cells data based on the user selection and so many other scenarios.
  