### PR TITLE
Replace the onlyDraggingThumb attribute in PlutoGridScrollbarConfig

### DIFF
--- a/lib/src/pluto_grid_configuration.dart
+++ b/lib/src/pluto_grid_configuration.dart
@@ -659,7 +659,8 @@ class PlutoGridScrollbarConfig {
   const PlutoGridScrollbarConfig({
     this.draggableScrollbar = true,
     this.isAlwaysShown = false,
-    this.onlyDraggingThumb = true,
+    this.onlyDraggingHorizontalThumb = false,
+    this.onlyDraggingVerticalThumb = false,
     this.enableScrollAfterDragEnd = true,
     this.scrollbarThickness = PlutoScrollbar.defaultThickness,
     this.scrollbarThicknessWhileDragging =
@@ -680,8 +681,11 @@ class PlutoGridScrollbarConfig {
 
   final bool isAlwaysShown;
 
-  /// If [onlyDraggingThumb] is false, scrolling can be done by dragging the track area.
-  final bool onlyDraggingThumb;
+  /// If [onlyDraggingHorizontalThumb] is true,horizontal scrolling can be done by dragging horizontal the track area.
+  final bool onlyDraggingHorizontalThumb;
+
+  /// If [onlyDraggingVerticalThumb] is true,vertical scrolling can be done by dragging vertical the track area.
+  final bool onlyDraggingVerticalThumb;
 
   /// If you release the scroll bar after scrolling,
   /// the scroll bar moves further according to the moving speed.
@@ -722,7 +726,8 @@ class PlutoGridScrollbarConfig {
             runtimeType == other.runtimeType &&
             draggableScrollbar == other.draggableScrollbar &&
             isAlwaysShown == other.isAlwaysShown &&
-            onlyDraggingThumb == other.onlyDraggingThumb &&
+            onlyDraggingHorizontalThumb == other.onlyDraggingHorizontalThumb &&
+            onlyDraggingVerticalThumb == other.onlyDraggingVerticalThumb &&
             enableScrollAfterDragEnd == other.enableScrollAfterDragEnd &&
             scrollbarThickness == other.scrollbarThickness &&
             scrollbarThicknessWhileDragging ==
@@ -743,7 +748,8 @@ class PlutoGridScrollbarConfig {
   int get hashCode => Object.hash(
         draggableScrollbar,
         isAlwaysShown,
-        onlyDraggingThumb,
+        onlyDraggingHorizontalThumb,
+        onlyDraggingVerticalThumb,
         enableScrollAfterDragEnd,
         scrollbarThickness,
         scrollbarThicknessWhileDragging,

--- a/lib/src/ui/pluto_body_rows.dart
+++ b/lib/src/ui/pluto_body_rows.dart
@@ -77,7 +77,8 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
       horizontalController:
           scrollbarConfig.draggableScrollbar ? _horizontalScroll : null,
       isAlwaysShown: scrollbarConfig.isAlwaysShown,
-      onlyDraggingThumb: scrollbarConfig.onlyDraggingThumb,
+      onlyDraggingHorizontalThumb: scrollbarConfig.onlyDraggingHorizontalThumb,
+      onlyDraggingVerticalThumb: scrollbarConfig.onlyDraggingVerticalThumb,
       enableHover: PlatformHelper.isDesktop,
       enableScrollAfterDragEnd: scrollbarConfig.enableScrollAfterDragEnd,
       thickness: scrollbarConfig.scrollbarThickness,
@@ -93,13 +94,13 @@ class PlutoBodyRowsState extends PlutoStateWithChange<PlutoBodyRows> {
       child: SingleChildScrollView(
         controller: _horizontalScroll,
         scrollDirection: Axis.horizontal,
-        physics: const ClampingScrollPhysics(),
+        physics: scrollbarConfig.onlyDraggingHorizontalThumb ? const NeverScrollableScrollPhysics() : const ClampingScrollPhysics(),
         child: CustomSingleChildLayout(
           delegate: ListResizeDelegate(stateManager, _columns),
           child: ListView.builder(
             controller: _verticalScroll,
             scrollDirection: Axis.vertical,
-            physics: const ClampingScrollPhysics(),
+            physics: scrollbarConfig.onlyDraggingVerticalThumb ? const NeverScrollableScrollPhysics() : const ClampingScrollPhysics(),
             itemCount: _rows.length,
             itemExtent: stateManager.rowTotalHeight,
             addRepaintBoundaries: false,

--- a/lib/src/widgets/pluto_scrollbar.dart
+++ b/lib/src/widgets/pluto_scrollbar.dart
@@ -38,7 +38,8 @@ class PlutoScrollbar extends StatefulWidget {
     this.horizontalController,
     this.verticalController,
     this.isAlwaysShown = false,
-    this.onlyDraggingThumb = true,
+    this.onlyDraggingHorizontalThumb = false,
+    this.onlyDraggingVerticalThumb = false,
     this.enableHover = true,
     this.enableScrollAfterDragEnd = true,
     this.thickness = defaultThickness,
@@ -68,7 +69,8 @@ class PlutoScrollbar extends StatefulWidget {
 
   final bool isAlwaysShown;
 
-  final bool onlyDraggingThumb;
+  final bool onlyDraggingHorizontalThumb;
+  final bool onlyDraggingVerticalThumb;
 
   final bool enableHover;
 
@@ -436,7 +438,8 @@ class PlutoGridCupertinoScrollbarState extends State<PlutoScrollbar>
         customPaintKey: _customPaintKey,
         debugOwner: this,
         duration: widget.longPressDuration,
-        onlyDraggingThumb: widget.onlyDraggingThumb,
+        onlyDraggingHorizontalThumb: widget.onlyDraggingHorizontalThumb,
+        onlyDraggingVerticalThumb: widget.onlyDraggingVerticalThumb,
       ),
       (_ThumbPressGestureRecognizer instance) {
         instance
@@ -1389,7 +1392,8 @@ class _ThumbPressGestureRecognizer extends LongPressGestureRecognizer {
     required GlobalKey customPaintKey,
     required Object debugOwner,
     required Duration duration,
-    this.onlyDraggingThumb = false,
+    this.onlyDraggingHorizontalThumb = false,
+    this.onlyDraggingVerticalThumb = false,
   })  : _customPaintKey = customPaintKey,
         super(
           postAcceptSlopTolerance: postAcceptSlopTolerance,
@@ -1399,12 +1403,14 @@ class _ThumbPressGestureRecognizer extends LongPressGestureRecognizer {
         );
 
   final GlobalKey _customPaintKey;
-  final bool onlyDraggingThumb;
+  final bool onlyDraggingHorizontalThumb;
+
+  final bool onlyDraggingVerticalThumb;
 
   @override
   bool isPointerAllowed(PointerDownEvent event) {
     if (!_hitTestInteractive(
-        _customPaintKey, event.position, event.kind, onlyDraggingThumb)) {
+        _customPaintKey, event.position, event.kind, onlyDraggingHorizontalThumb,onlyDraggingVerticalThumb)) {
       return false;
     }
     return super.isPointerAllowed(event);
@@ -1415,7 +1421,7 @@ class _ThumbPressGestureRecognizer extends LongPressGestureRecognizer {
 // scrollbar should only respond to a gesture directly on its thumb, so
 // manually check for a hit on the thumb here.
 bool _hitTestInteractive(GlobalKey customPaintKey, Offset offset,
-    PointerDeviceKind kind, bool onlyDraggingThumb) {
+    PointerDeviceKind kind,bool onlyDraggingHorizontalThumb,bool onlyDraggingVerticalThumb) {
   if (customPaintKey.currentContext == null) {
     return false;
   }
@@ -1425,7 +1431,7 @@ bool _hitTestInteractive(GlobalKey customPaintKey, Offset offset,
       customPaint.foregroundPainter! as _ScrollbarPainter;
   final Offset localOffset = _getLocalOffset(customPaintKey, offset);
   // We can only receive track taps that are on the thumb.
-  return onlyDraggingThumb
+  return onlyDraggingHorizontalThumb || onlyDraggingVerticalThumb
       ? painter.hitTestOnlyThumbInteractive(localOffset, kind)
       : painter.hitTestInteractive(localOffset, kind);
 }


### PR DESCRIPTION
use “onlyDraggingHorizontalThumb” and ”onlyDraggingVerticalThumb“ achieve separate control vertical and horizontal scrolling 
fixes #944 