### PR TITLE
On grouped rows allow row check from certain depth - Allow textEditingController function in pluto column - Allow barrierDismissible in pluto grid popup

### DIFF
--- a/lib/src/model/pluto_column.dart
+++ b/lib/src/model/pluto_column.dart
@@ -147,7 +147,8 @@ class PlutoColumn {
 
   /// A checkbox appears in the cell of the column.
   bool enableRowChecked;
-
+  int rowCheckBoxGroupDepth;
+    
   /// Sort rows by tapping on the column heading.
   bool enableSorting;
 
@@ -192,6 +193,8 @@ class PlutoColumn {
   /// Hide the column.
   bool hide;
 
+  Function()? textEditingControllerListener;
+
   PlutoColumn({
     required this.title,
     required this.field,
@@ -217,6 +220,7 @@ class PlutoColumn {
     this.enableColumnDrag = true,
     this.enableRowDrag = false,
     this.enableRowChecked = false,
+    this.rowCheckBoxGroupDepth = 0,
     this.enableSorting = true,
     this.enableContextMenu = true,
     this.enableDropToResize = true,
@@ -226,6 +230,7 @@ class PlutoColumn {
     this.enableAutoEditing = false,
     this.enableEditingMode = true,
     this.hide = false,
+    this.textEditingControllerListener,
   })  : _key = UniqueKey(),
         _checkReadOnly = checkReadOnly;
 

--- a/lib/src/pluto_grid_popup.dart
+++ b/lib/src/pluto_grid_popup.dart
@@ -75,6 +75,8 @@ class PlutoGridPopup {
 
   final double? height;
 
+  final bool? barrierDismissible;
+  
   PlutoGridPopup({
     required this.context,
     required this.columns,
@@ -98,6 +100,7 @@ class PlutoGridPopup {
     this.mode = PlutoGridMode.normal,
     this.width,
     this.height,
+    this.barrierDismissible,
   }) {
     open();
   }
@@ -111,6 +114,7 @@ class PlutoGridPopup {
 
     PlutoGridOnSelectedEvent? selected =
         await showDialog<PlutoGridOnSelectedEvent>(
+            barrierDismissible: barrierDismissible ?? true,
             context: context,
             builder: (BuildContext ctx) {
               return Dialog(

--- a/lib/src/ui/cells/pluto_default_cell.dart
+++ b/lib/src/ui/cells/pluto_default_cell.dart
@@ -158,14 +158,14 @@ class _PlutoDefaultCellState extends PlutoStateWithChange<PlutoDefaultCell> {
               )
             : widget.row.type.group.expanded
                 ? Icon(
-                    style.rowGroupExpandedIcon,
-                    size: style.iconSize,
-                    color: style.iconColor,
+                    Icons.remove_circle_outline,
+                    size: 15,
+                    color: Colors.black38,
                   )
                 : Icon(
-                    style.rowGroupCollapsedIcon,
-                    size: style.iconSize,
-                    color: style.iconColor,
+                    Icons.add_circle_outline,
+                    size: 15,
+                    color: Colors.black38,
                   ),
       );
     }

--- a/lib/src/ui/cells/pluto_default_cell.dart
+++ b/lib/src/ui/cells/pluto_default_cell.dart
@@ -119,6 +119,13 @@ class _PlutoDefaultCellState extends PlutoStateWithChange<PlutoDefaultCell> {
 
   @override
   Widget build(BuildContext context) {
+    int depth = 0;
+    PlutoRow? row = widget.row;
+    while (row?.parent != null) {
+      depth++;
+      row = row?.parent;
+    }
+
     final cellWidget = _DefaultCellWidget(
       stateManager: stateManager,
       rowIdx: widget.rowIdx,
@@ -177,7 +184,7 @@ class _PlutoDefaultCellState extends PlutoStateWithChange<PlutoDefaultCell> {
             color: style.iconColor,
           ),
         ),
-      if (widget.column.enableRowChecked)
+      if (widget.column.enableRowChecked && depth >= widget.column.rowCheckBoxGroupDepth)
         CheckboxSelectionWidget(
           column: widget.column,
           row: widget.row,

--- a/lib/src/ui/cells/pluto_default_cell.dart
+++ b/lib/src/ui/cells/pluto_default_cell.dart
@@ -149,6 +149,7 @@ class _PlutoDefaultCellState extends PlutoStateWithChange<PlutoDefaultCell> {
     Widget? expandIcon;
     if (_canExpand) {
       expandIcon = IconButton(
+        padding: EdgeInsets.only(bottom: 0.0),
         onPressed: _isEmptyGroup ? null : _handleToggleExpandedRowGroup,
         icon: _isEmptyGroup
             ? Icon(

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -231,6 +231,10 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
       cellFocus.requestFocus();
     }
 
+    if (widget.column.textEditingControllerListener != null) {
+      _textController.addListener(widget.column.textEditingControllerListener!);
+    }
+
     return TextField(
       focusNode: cellFocus,
       controller: _textController,

--- a/lib/src/ui/columns/pluto_column_title.dart
+++ b/lib/src/ui/columns/pluto_column_title.dart
@@ -395,7 +395,7 @@ class _ColumnWidget extends StatelessWidget {
                 alignment: Alignment.centerLeft,
                 child: Row(
                   children: [
-                    if (column.enableRowChecked)
+                    if (column.enableRowChecked && column.rowCheckBoxGroupDepth == 0)
                       CheckboxAllSelectionWidget(stateManager: stateManager),
                     Expanded(
                       child: _ColumnTextWidget(


### PR DESCRIPTION
On grouped rows allow more control of rows checked through rowCheckBoxGroupDepth property.
Enable a new property on pluto column, texteEditeingControllerListener wich receives a custom textEditingController function.
Enable a new property on pluto grid popup, barrierDismissible true or false.