### PR TITLE
chore: fix a compile error after `flutter 3.19`

### DIFF
--- a/lib/src/helper/pluto_key_manager_event.dart
+++ b/lib/src/helper/pluto_key_manager_event.dart
@@ -3,7 +3,7 @@ import 'package:flutter/services.dart';
 
 class PlutoKeyManagerEvent {
   FocusNode focusNode;
-  RawKeyEvent event;
+  KeyEvent event;
 
   PlutoKeyManagerEvent({
     required this.focusNode,
@@ -94,15 +94,16 @@ class PlutoKeyManagerEvent {
   }
 
   bool get isShiftPressed {
-    return event.isShiftPressed;
+    return HardwareKeyboard.instance.isShiftPressed;
   }
 
   bool get isCtrlPressed {
-    return event.isMetaPressed || event.isControlPressed;
+    return HardwareKeyboard.instance.isMetaPressed ||
+        HardwareKeyboard.instance.isControlPressed;
   }
 
   bool get isAltPressed {
-    return event.isAltPressed;
+    return HardwareKeyboard.instance.isAltPressed;
   }
 
   bool get isModifierPressed {

--- a/lib/src/manager/pluto_grid_key_manager.dart
+++ b/lib/src/manager/pluto_grid_key_manager.dart
@@ -79,7 +79,7 @@ class PlutoGridKeyManager {
     if (stateManager.configuration.shortcut.handle(
       keyEvent: keyEvent,
       stateManager: stateManager,
-      state: RawKeyboard.instance,
+      state: HardwareKeyboard.instance,
     )) {
       return;
     }

--- a/lib/src/manager/shortcut/pluto_grid_shortcut.dart
+++ b/lib/src/manager/shortcut/pluto_grid_shortcut.dart
@@ -27,7 +27,7 @@ class PlutoGridShortcut {
   bool handle({
     required PlutoKeyManagerEvent keyEvent,
     required PlutoGridStateManager stateManager,
-    required RawKeyboard state,
+    required HardwareKeyboard state,
   }) {
     for (final action in actions.entries) {
       if (action.key.accepts(keyEvent.event, state)) {

--- a/lib/src/manager/shortcut/pluto_grid_shortcut_action.dart
+++ b/lib/src/manager/shortcut/pluto_grid_shortcut_action.dart
@@ -250,7 +250,7 @@ class PlutoGridActionDefaultTab extends PlutoGridShortcutAction {
 
     final saveIsEditing = stateManager.isEditing;
 
-    keyEvent.event.isShiftPressed
+    HardwareKeyboard.instance.isShiftPressed
         ? _moveCellPrevious(stateManager)
         : _moveCellNext(stateManager);
 
@@ -408,7 +408,7 @@ class PlutoGridActionDefaultEnterKey extends PlutoGridShortcutAction {
     }
 
     if (enterKeyAction.isEditingAndMoveDown) {
-      if (keyEvent.event.isShiftPressed) {
+      if (HardwareKeyboard.instance.isShiftPressed) {
         stateManager.moveCurrentCell(
           PlutoMoveDirection.up,
           notify: false,
@@ -420,7 +420,7 @@ class PlutoGridActionDefaultEnterKey extends PlutoGridShortcutAction {
         );
       }
     } else if (enterKeyAction.isEditingAndMoveRight) {
-      if (keyEvent.event.isShiftPressed) {
+      if (HardwareKeyboard.instance.isShiftPressed) {
         stateManager.moveCurrentCell(
           PlutoMoveDirection.left,
           force: true,

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -593,7 +593,7 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
     }
   }
 
-  KeyEventResult _handleGridFocusOnKey(FocusNode focusNode, RawKeyEvent event) {
+  KeyEventResult _handleGridFocusOnKey(FocusNode focusNode, KeyEvent event) {
     if (_keyManager.eventResult.isSkip == false) {
       _keyManager.subject.add(PlutoKeyManagerEvent(
         focusNode: focusNode,
@@ -608,7 +608,7 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
   Widget build(BuildContext context) {
     return FocusScope(
       onFocusChange: _stateManager.setKeepFocus,
-      onKey: _handleGridFocusOnKey,
+      onKeyEvent: _handleGridFocusOnKey,
       child: _GridContainer(
         stateManager: _stateManager,
         child: LayoutBuilder(

--- a/lib/src/ui/cells/popup_cell.dart
+++ b/lib/src/ui/cells/popup_cell.dart
@@ -62,7 +62,7 @@ mixin PopupCellState<T extends PopupCell> on State<T>
       ..text =
           widget.column.formattedValueForDisplayInEditing(widget.cell.value);
 
-    textFocus = FocusNode(onKey: _handleKeyboardFocusOnKey);
+    textFocus = FocusNode(onKeyEvent: _handleKeyboardFocusOnKey);
   }
 
   @override
@@ -175,7 +175,7 @@ mixin PopupCellState<T extends PopupCell> on State<T>
     }
   }
 
-  KeyEventResult _handleKeyboardFocusOnKey(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _handleKeyboardFocusOnKey(FocusNode node, KeyEvent event) {
     var keyManager = PlutoKeyManagerEvent(
       focusNode: node,
       event: event,

--- a/lib/src/ui/cells/text_cell.dart
+++ b/lib/src/ui/cells/text_cell.dart
@@ -52,7 +52,7 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
   void initState() {
     super.initState();
 
-    cellFocus = FocusNode(onKey: _handleOnKey);
+    cellFocus = FocusNode(onKeyEvent: _handleOnKey);
 
     widget.stateManager.setTextEditingController(_textController);
 
@@ -172,7 +172,7 @@ mixin TextCellState<T extends TextCell> on State<T> implements TextFieldProps {
     });
   }
 
-  KeyEventResult _handleOnKey(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _handleOnKey(FocusNode node, KeyEvent event) {
     var keyManager = PlutoKeyManagerEvent(
       focusNode: node,
       event: event,

--- a/lib/src/ui/columns/pluto_column_filter.dart
+++ b/lib/src/ui/columns/pluto_column_filter.dart
@@ -83,7 +83,7 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
   initState() {
     super.initState();
 
-    _focusNode = FocusNode(onKey: _handleOnKey);
+    _focusNode = FocusNode(onKeyEvent: _handleOnKey);
 
     widget.column.setFilterFocusNode(_focusNode);
 
@@ -145,7 +145,7 @@ class PlutoColumnFilterState extends PlutoStateWithChange<PlutoColumnFilter> {
     stateManager.notifyListeners();
   }
 
-  KeyEventResult _handleOnKey(FocusNode node, RawKeyEvent event) {
+  KeyEventResult _handleOnKey(FocusNode node, KeyEvent event) {
     var keyManager = PlutoKeyManagerEvent(
       focusNode: node,
       event: event,

--- a/test/src/helper/pluto_key_manager_event_test.dart
+++ b/test/src/helper/pluto_key_manager_event_test.dart
@@ -8,7 +8,7 @@ void main() {
 
   late PlutoKeyManagerEvent? keyManagerEvent;
 
-  KeyEventResult callback(FocusNode node, RawKeyEvent event) {
+  KeyEventResult callback(FocusNode node, KeyEvent event) {
     keyManagerEvent = PlutoKeyManagerEvent(
       focusNode: node,
       event: event,
@@ -28,12 +28,12 @@ void main() {
 
   Future<void> buildWidget({
     required WidgetTester tester,
-    required KeyEventResult Function(FocusNode, RawKeyEvent) callback,
+    required KeyEventResult Function(FocusNode, KeyEvent) callback,
   }) async {
     await tester.pumpWidget(MaterialApp(
       home: FocusScope(
         autofocus: true,
-        onKey: callback,
+        onKeyEvent: callback,
         child: Focus(
           focusNode: focusNode,
           child: const SizedBox(width: 100, height: 100),
@@ -62,7 +62,7 @@ void main() {
     (tester) async {
       late PlutoKeyManagerEvent keyManagerEvent;
 
-      KeyEventResult callback(FocusNode node, RawKeyEvent event) {
+      KeyEventResult callback(FocusNode node, KeyEvent event) {
         keyManagerEvent = PlutoKeyManagerEvent(
           focusNode: node,
           event: event,

--- a/test/src/manager/pluto_grid_key_manager_test.dart
+++ b/test/src/manager/pluto_grid_key_manager_test.dart
@@ -46,8 +46,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -98,8 +98,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -150,8 +150,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -204,8 +204,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -258,8 +258,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -311,8 +311,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,
@@ -440,8 +440,8 @@ void main() {
       await tester.pumpWidget(
         MaterialApp(
           home: Material(
-            child: RawKeyboardListener(
-              onKey: (event) {
+            child: KeyboardListener(
+              onKeyEvent: (event) {
                 keyManager.subject.add(PlutoKeyManagerEvent(
                   focusNode: FocusNode(),
                   event: event,


### PR DESCRIPTION
RawKeyEvent was deprecated and removed since flutter 3.19.

I apply this breaking changes into `pluto_grid`.
