### PR TITLE
Bubble up key events incl. shortcuts that are not handled by PlutoGrid

### DIFF
--- a/lib/src/manager/pluto_grid_key_manager.dart
+++ b/lib/src/manager/pluto_grid_key_manager.dart
@@ -73,6 +73,10 @@ class PlutoGridKeyManager {
     _subscription = MergeStream([normalStream, movingStream]).listen(_handler);
   }
 
+  bool isDefaultAction(PlutoKeyManagerEvent keyEvent){
+    return !keyEvent.isModifierPressed && keyEvent.isCharacter;
+  }
+
   void _handler(PlutoKeyManagerEvent keyEvent) {
     if (keyEvent.isKeyUpEvent) return;
 
@@ -88,7 +92,7 @@ class PlutoGridKeyManager {
   }
 
   void _handleDefaultActions(PlutoKeyManagerEvent keyEvent) {
-    if (!keyEvent.isModifierPressed && keyEvent.isCharacter) {
+    if (isDefaultAction(keyEvent)) {
       _handleCharacter(keyEvent);
       return;
     }

--- a/lib/src/manager/shortcut/pluto_grid_shortcut.dart
+++ b/lib/src/manager/shortcut/pluto_grid_shortcut.dart
@@ -39,6 +39,14 @@ class PlutoGridShortcut {
     return false;
   }
 
+  bool shortcutHasAction({
+    required PlutoKeyManagerEvent keyEvent,
+    required HardwareKeyboard state
+  }) {
+    var handledActions = actions.entries.where((action) => action.key.accepts(keyEvent.event, state));
+    return handledActions.isNotEmpty;
+  }
+
   static final Map<ShortcutActivator, PlutoGridShortcutAction> defaultActions =
       {
     // Move cell focus

--- a/lib/src/pluto_grid.dart
+++ b/lib/src/pluto_grid.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'dart:ui';
 
+import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:intl/intl.dart' show Intl;
@@ -595,13 +596,22 @@ class PlutoGridState extends PlutoStateWithChange<PlutoGrid> {
 
   KeyEventResult _handleGridFocusOnKey(FocusNode focusNode, KeyEvent event) {
     if (_keyManager.eventResult.isSkip == false) {
-      _keyManager.subject.add(PlutoKeyManagerEvent(
+      PlutoKeyManagerEvent plutoKeyEvent = PlutoKeyManagerEvent(
         focusNode: focusNode,
         event: event,
-      ));
+      );
+      _keyManager.subject.add(plutoKeyEvent);
+
+      bool isDefaultAction =  _keyManager.isDefaultAction(plutoKeyEvent);
+      bool shortcutHasAction = isDefaultAction ? false : stateManager.configuration.shortcut.shortcutHasAction(
+          keyEvent: plutoKeyEvent,
+          state: HardwareKeyboard.instance
+      );
+
+      return _keyManager.eventResult.consume(isDefaultAction || shortcutHasAction ? KeyEventResult.handled : KeyEventResult.ignored);
     }
 
-    return _keyManager.eventResult.consume(KeyEventResult.handled);
+    return _keyManager.eventResult.consume(KeyEventResult.ignored);
   }
 
   @override


### PR DESCRIPTION
`PlutoGridState` registers its own key handler  `_handleGridFocusKeyOnly` via the `FocusScope` widget and `onKeyEvent` property. The registered key handler always returns `KeyEventResult.handled`. This prevents parent widgets to use own shortcuts because key events are not "bubbled up" in the widget hierarchy.

Pluto Grid defines its own "default actions" and "shortcuts". It is desirable that only these are prevented from "bubbling up" and all other key events are passed on to parent widgets.

With this PR we implemented this behavior in `PlutoGridState._handleGridFocusOnKey`.