### PR TITLE
Fix Key Event Error in New Flutter Version

### DIFF
--- a/lib/pluto_grid.dart
+++ b/lib/pluto_grid.dart
@@ -1,5 +1,4 @@
 library pluto_grid;
-
 export './src/helper/filter_helper.dart';
 export './src/helper/filtered_list.dart';
 export './src/helper/pluto_aggregate_helper.dart';

--- a/lib/src/manager/shortcut/pluto_grid_shortcut.dart
+++ b/lib/src/manager/shortcut/pluto_grid_shortcut.dart
@@ -30,10 +30,21 @@ class PlutoGridShortcut {
     required HardwareKeyboard state,
   }) {
     for (final action in actions.entries) {
-      if (action.key.accepts(keyEvent.event, state)) {
+     // Original code snippet
+      // The following code checks if the action's key accepts the keyEvent and executes the action if true.
+      // However, it caused an error in the new version of Flutter due to type changes.
+      // if (action.key.accepts(keyEvent.event, state)) {
+      //   action.value.execute(keyEvent: keyEvent, stateManager: stateManager);
+      //   return true;
+  // }
+
+  // Updated code snippet to fix the error in the new version of Flutter
+    // The keyEvent.event needs to be explicitly cast to KeyEvent and the state to HardwareKeyboard.
+    if (action.key.accepts(keyEvent.event as KeyEvent, state as HardwareKeyboard)) {
         action.value.execute(keyEvent: keyEvent, stateManager: stateManager);
-        return true;
+      return true;
       }
+
     }
 
     return false;


### PR DESCRIPTION
This pull request addresses an issue with key event handling in the new version of Flutter. The original code caused a type error due to changes in how key events and states are managed. The updated code snippet explicitly casts " keyEvent.event " as "KeyEvent " and "state" as "HardwareKeyboard", resolving the error.

**Changes Made**

**File Location:**

> lib/src/manager/shortcut/pluto_grid_shortcut.dart (line 33)

**Original Code:**
```
if (action.key.accepts(keyEvent.event, state)) {
   action.value.execute(keyEvent: keyEvent, stateManager: stateManager);
   return true;
 }
```

**Updated Code:**
```
if (action.key.accepts(keyEvent.event as KeyEvent, state as HardwareKeyboard)) {
  action.value.execute(keyEvent: keyEvent, stateManager: stateManager);
  return true;
}
```
**Reason for Changes**
In the new version of Flutter, there were type changes that caused the original code to throw an error. By explicitly casting the types, the code is now compatible with the updated Flutter API.

The updated code has been tested and verified to work correctly without causing the previous type error.