### PR TITLE
fix: notify listeners on setConfiguration and setTextDirection changes

### DIFF
--- a/lib/src/manager/pluto_change_notifier_filter.dart
+++ b/lib/src/manager/pluto_change_notifier_filter.dart
@@ -107,6 +107,7 @@ abstract class PlutoChangeNotifierFilterResolver {
 
       /// grid_state
       stateManager.resetCurrentState.hashCode: 'resetCurrentState',
+      stateManager.setConfiguration.hashCode: 'setConfiguration',
 
       /// layout_state
       stateManager.setShowColumnTitle.hashCode: 'setShowColumnTitle',
@@ -115,6 +116,7 @@ abstract class PlutoChangeNotifierFilterResolver {
       stateManager.setShowLoading.hashCode: 'setShowLoading',
       stateManager.notifyChangedShowFrozenColumn.hashCode:
           'notifyChangedShowFrozenColumn',
+      stateManager.setTextDirection.hashCode: 'setTextDirection',
 
       /// pagination_state
       stateManager.setPageSize.hashCode: 'setPageSize',

--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -149,7 +149,7 @@ mixin GridState implements IPlutoGridState {
       _state._configuration!.applyColumnFilter(refColumns.originalList);
     }
 
-    notifyListeners(notify, setConfiguration.hashCode);
+    notifyListeners(notify);
   }
 
   @override

--- a/lib/src/manager/state/grid_state.dart
+++ b/lib/src/manager/state/grid_state.dart
@@ -60,6 +60,7 @@ abstract class IGridState {
     PlutoGridConfiguration configuration, {
     bool updateLocale = true,
     bool applyColumnFilter = true,
+    bool notify = true,
   });
 
   void setGridMode(PlutoGridMode mode);
@@ -134,6 +135,7 @@ mixin GridState implements IPlutoGridState {
     PlutoGridConfiguration configuration, {
     bool updateLocale = true,
     bool applyColumnFilter = true,
+    bool notify = true,
   }) {
     if (_state._configuration == configuration) return;
 
@@ -146,6 +148,8 @@ mixin GridState implements IPlutoGridState {
     if (applyColumnFilter) {
       _state._configuration!.applyColumnFilter(refColumns.originalList);
     }
+
+    notifyListeners(notify, setConfiguration.hashCode);
   }
 
   @override

--- a/lib/src/manager/state/layout_state.dart
+++ b/lib/src/manager/state/layout_state.dart
@@ -120,7 +120,7 @@ abstract class ILayoutState {
 
   void notifyChangedShowFrozenColumn();
 
-  void setTextDirection(TextDirection textDirection);
+  void setTextDirection(TextDirection textDirection, {bool notify = true});
 
   @visibleForTesting
   void setGridGlobalOffset(Offset offset);
@@ -503,8 +503,18 @@ mixin LayoutState implements IPlutoGridState {
   }
 
   @override
-  void setTextDirection(TextDirection textDirection) {
+  void setTextDirection(TextDirection textDirection, {bool notify = true}) {
+    if (_state._textDirection == textDirection) return;
+
     _state._textDirection = textDirection;
+
+    // setTextDirection is invoked from PlutoGridLayoutDelegate's constructor,
+    // which is created while PlutoGrid itself is building (inside
+    // LayoutBuilder). Notifying synchronously at that point would ask
+    // dependent widgets to rebuild while the widget tree above them is still
+    // being built, which Flutter disallows. Defer to the next frame instead,
+    // matching the pattern already used by setKeepFocus.
+    notifyListenersOnPostFrame(notify, setTextDirection.hashCode);
   }
 
   @override

--- a/lib/src/manager/state/layout_state.dart
+++ b/lib/src/manager/state/layout_state.dart
@@ -514,7 +514,7 @@ mixin LayoutState implements IPlutoGridState {
     // dependent widgets to rebuild while the widget tree above them is still
     // being built, which Flutter disallows. Defer to the next frame instead,
     // matching the pattern already used by setKeepFocus.
-    notifyListenersOnPostFrame(notify, setTextDirection.hashCode);
+    notifyListenersOnPostFrame(notify);
   }
 
   @override

--- a/test/mock/shared_mocks.mocks.dart
+++ b/test/mock/shared_mocks.mocks.dart
@@ -2427,6 +2427,7 @@ class MockPlutoGridStateManager extends _i1.Mock
     _i2.PlutoGridConfiguration? configuration, {
     bool? updateLocale = true,
     bool? applyColumnFilter = true,
+    bool? notify = true,
   }) =>
       super.noSuchMethod(
         Invocation.method(
@@ -2435,6 +2436,7 @@ class MockPlutoGridStateManager extends _i1.Mock
           {
             #updateLocale: updateLocale,
             #applyColumnFilter: applyColumnFilter,
+            #notify: notify,
           },
         ),
         returnValueForMissingStub: null,
@@ -2774,10 +2776,15 @@ class MockPlutoGridStateManager extends _i1.Mock
       );
 
   @override
-  void setTextDirection(_i5.TextDirection? textDirection) => super.noSuchMethod(
+  void setTextDirection(
+    _i5.TextDirection? textDirection, {
+    bool? notify = true,
+  }) =>
+      super.noSuchMethod(
         Invocation.method(
           #setTextDirection,
           [textDirection],
+          {#notify: notify},
         ),
         returnValueForMissingStub: null,
       );

--- a/test/src/manager/state/grid_state_test.dart
+++ b/test/src/manager/state/grid_state_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:pluto_grid/pluto_grid.dart';
+
+import '../../../helper/column_helper.dart';
+import '../../../helper/row_helper.dart';
+import '../../../mock/mock_methods.dart';
+import '../../../mock/shared_mocks.mocks.dart';
+
+void main() {
+  PlutoGridStateManager createStateManager({
+    required List<PlutoColumn> columns,
+    required List<PlutoRow> rows,
+    FocusNode? gridFocusNode,
+    PlutoGridScrollController? scroll,
+    PlutoGridConfiguration configuration = const PlutoGridConfiguration(),
+  }) {
+    final stateManager = PlutoGridStateManager(
+      columns: columns,
+      rows: rows,
+      gridFocusNode: gridFocusNode ?? MockFocusNode(),
+      scroll: scroll ?? MockPlutoGridScrollController(),
+      configuration: configuration,
+    );
+
+    stateManager.setEventManager(MockPlutoGridEventManager());
+
+    return stateManager;
+  }
+
+  group('setConfiguration', () {
+    testWidgets(
+      'When the configuration is changed, listeners should be notified.',
+      (WidgetTester tester) async {
+        // given
+        List<PlutoColumn> columns = ColumnHelper.textColumn('body', count: 3);
+        List<PlutoRow> rows = RowHelper.count(3, columns);
+
+        PlutoGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+        );
+
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setConfiguration(
+          const PlutoGridConfiguration(
+            style: PlutoGridStyleConfig(enableGridBorderShadow: true),
+          ),
+        );
+
+        // then
+        verify(listener.noParamReturnVoid()).called(1);
+      },
+    );
+
+    testWidgets(
+      'When the configuration is set to an equal value, '
+      'listeners should not be notified.',
+      (WidgetTester tester) async {
+        // given
+        List<PlutoColumn> columns = ColumnHelper.textColumn('body', count: 3);
+        List<PlutoRow> rows = RowHelper.count(3, columns);
+
+        const configuration = PlutoGridConfiguration();
+
+        PlutoGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+          configuration: configuration,
+        );
+
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setConfiguration(configuration);
+
+        // then
+        verifyNever(listener.noParamReturnVoid());
+      },
+    );
+
+    testWidgets(
+      'When notify is false, listeners should not be notified '
+      'even though the configuration changed.',
+      (WidgetTester tester) async {
+        // given
+        List<PlutoColumn> columns = ColumnHelper.textColumn('body', count: 3);
+        List<PlutoRow> rows = RowHelper.count(3, columns);
+
+        PlutoGridStateManager stateManager = createStateManager(
+          columns: columns,
+          rows: rows,
+        );
+
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setConfiguration(
+          const PlutoGridConfiguration(
+            style: PlutoGridStyleConfig(enableGridBorderShadow: true),
+          ),
+          notify: false,
+        );
+
+        // then
+        verifyNever(listener.noParamReturnVoid());
+      },
+    );
+  });
+}

--- a/test/src/manager/state/layout_state_test.dart
+++ b/test/src/manager/state/layout_state_test.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:pluto_grid/pluto_grid.dart';
 
 import '../../../helper/column_helper.dart';
 import '../../../helper/pluto_widget_test_helper.dart';
 import '../../../helper/row_helper.dart';
+import '../../../mock/mock_methods.dart';
 import '../../../mock/shared_mocks.mocks.dart';
 
 void main() {
@@ -155,6 +157,91 @@ void main() {
           (stateManager.gridGlobalOffset!.dx + stateManager.maxWidth!) -
               PlutoGridSettings.offsetScrollingFromEdge,
         );
+      },
+    );
+  });
+
+  group('setTextDirection', () {
+    late PlutoGridStateManager stateManager;
+
+    setUp(() {
+      List<PlutoColumn> columns = ColumnHelper.textColumn('body', count: 3);
+      List<PlutoRow> rows = RowHelper.count(3, columns);
+
+      stateManager = PlutoGridStateManager(
+        columns: columns,
+        rows: rows,
+        gridFocusNode: MockFocusNode(),
+        scroll: MockPlutoGridScrollController(),
+      );
+
+      stateManager.setEventManager(MockPlutoGridEventManager());
+    });
+
+    testWidgets(
+      'When the text direction is changed, '
+      'listeners should be notified on the next frame.',
+      (WidgetTester tester) async {
+        // given
+        expect(stateManager.isLTR, isTrue);
+
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setTextDirection(TextDirection.rtl);
+
+        // notifyListenersOnPostFrame defers the notification, so listeners
+        // must not have been called synchronously yet.
+        verifyNever(listener.noParamReturnVoid());
+
+        await tester.pump();
+
+        // then
+        expect(stateManager.isRTL, isTrue);
+        verify(listener.noParamReturnVoid()).called(1);
+      },
+    );
+
+    testWidgets(
+      'When the text direction is set to the same value, '
+      'listeners should not be notified.',
+      (WidgetTester tester) async {
+        // given
+        expect(stateManager.isLTR, isTrue);
+
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setTextDirection(TextDirection.ltr);
+
+        await tester.pump();
+
+        // then
+        verifyNever(listener.noParamReturnVoid());
+      },
+    );
+
+    testWidgets(
+      'When notify is false, listeners should not be notified '
+      'even though the text direction changed.',
+      (WidgetTester tester) async {
+        // given
+        final listener = MockMethods();
+
+        stateManager.addListener(listener.noParamReturnVoid);
+
+        // when
+        stateManager.setTextDirection(TextDirection.rtl, notify: false);
+
+        await tester.pump();
+
+        // then
+        expect(stateManager.isRTL, isTrue);
+        verifyNever(listener.noParamReturnVoid());
       },
     );
   });


### PR DESCRIPTION
### Root Cause

_Both setConfiguration() and setTextDirection() update the Grid's internal state, but neither method notified listeners after the state changed.

Many Grid components—especially cells that extend PlutoStateWithChange (such as Select, Date, and cells that display directional icons)—depend on notifyListeners() to know when they should rebuild.

As a result, when the Grid configuration or the RTL/LTR direction changed:_

The internal state was updated correctly.
The Cells were never notified about that update.
Therefore, they continued rendering using the previous configuration.
They only refreshed later if another unrelated action (such as selecting a cell, scrolling, or any event that triggered a rebuild) happened to call notifyListeners().

This created the impression that changing the application language did not fully update the Grid, even though the underlying configuration had already changed.

### Solution

The fix ensures that every time the internal configuration changes, the Grid immediately notifies all dependent listeners so that every affected Cell rebuilds using the latest configuration.

Two different notification strategies are used because the two methods execute in different lifecycle stages.

setConfiguration()

setConfiguration() is called outside the widget build process, so it is safe to invoke:

notifyListeners();

immediately after updating the internal configuration.

This allows all dependent Cells to rebuild instantly using the new configuration.

setTextDirection()

setTextDirection() is different.

It is invoked during the widget build process from PlutoGridLayoutDelegate's constructor.

Calling notifyListeners() directly at that point would trigger Flutter's:

setState() or markNeedsBuild() called during build

assertion.

For that reason, the notification is deferred until the current frame finishes by using:

notifyListenersOnPostFrame();

This follows the exact same pattern already used by setKeepFocus(), making the implementation consistent with the existing architecture while avoiding build-time notifications.

### Result

After this change:

Switching between RTL and LTR immediately updates every Grid Cell.
Select Cells rebuild correctly.
Date Cells rebuild correctly.
Directional icons are updated immediately.
No manual interaction is required to refresh the Grid.
Existing APIs and behavior remain unchanged.
The fix is centralized inside the Package and benefits every application that uses it.